### PR TITLE
Fix missing ucrtbased.dll in DEBUG build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -134,7 +134,7 @@ jobs:
         run: ./scripts/build.py
       - run: |
           mv -f yass.zip ${{ env.BUNDLE_NAME }}.zip
-          mv -f yass-standlone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
+          mv -f yass-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
       - uses: actions/upload-release-asset@v1
         if: ${{ github.event_name == 'release' }}
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -133,8 +133,8 @@ jobs:
       - name: Build
         run: ./scripts/build.py
       - run: |
-          mv -f darwin-yass.app.zip ${{ env.BUNDLE_NAME }}.zip
-          mv -f darwin-yass.app-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
+          mv -f yass.zip ${{ env.BUNDLE_NAME }}.zip
+          mv -f yass-standlone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
       - uses: actions/upload-release-asset@v1
         if: ${{ github.event_name == 'release' }}
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,9 +82,10 @@ jobs:
         shell: cmd
         run: |
           set VCToolsVersion=14.0
+          set Winsdk=10.0.19041.0
+          set "WindowsSDKVersion=%Winsdk%\"
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=x86 -host_arch=amd64
           set "CC=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
           set "CXX=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
@@ -93,14 +94,16 @@ jobs:
 
           set "Path=%CD%\third_party\nasm;%Path%"
 
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
+
           call "scripts\build-boringssl.bat"
       - name: "Install dependency: boringssl (x64 slice)"
         shell: cmd
         run: |
           set VCToolsVersion=14.0
+          set Winsdk=10.0.19041.0
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=amd64 -host_arch=amd64
           set "CC=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
           set "CXX=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
@@ -109,14 +112,16 @@ jobs:
 
           set "Path=%CD%\third_party\nasm;%Path%"
 
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
+
           call "scripts\build-boringssl.bat"
       - name: "Install dependency: boringssl (arm64 slice)"
         shell: cmd
         run: |
           set VCToolsVersion=14.29
+          set Winsdk=10.0.19041.0
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=arm64 -host_arch=amd64
           set "CC=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
           set "CXX=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
@@ -124,6 +129,8 @@ jobs:
           set Platform=arm64
 
           set "Path=%CD%\third_party\nasm;%Path%"
+
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
           call "scripts\build-boringssl.bat"
       - name: "Install dependency: boringssl (x86-xp slice)"
@@ -143,9 +150,9 @@ jobs:
           set COMPILER_TARGET=i686-pc-windows-msvc
           set ALLOW_XP=on
 
-          call "scripts\callxp-%Platform%.cmd"
-
           set "Path=%CD%\third_party\nasm;%Path%"
+
+          call "scripts\callxp-%Platform%.cmd"
 
           call "scripts\build-boringssl.bat"
       - name: "Install dependency: boringssl (x64-xp slice)"
@@ -165,9 +172,9 @@ jobs:
           set COMPILER_TARGET=x86_64-pc-windows-msvc
           set ALLOW_XP=on
 
-          call "scripts\callxp-%Platform%.cmd"
-
           set "Path=%CD%\third_party\nasm;%Path%"
+
+          call "scripts\callxp-%Platform%.cmd"
 
           call "scripts\build-boringssl.bat"
   win-msvc-release:
@@ -226,14 +233,17 @@ jobs:
       - name: Build
         run: |
           set VCToolsVersion=14.0
+          set Winsdk=10.0.19041.0
+          set "WindowsSDKVersion=%Winsdk%\"
           if "${{ matrix.arch }}" == "arm64" (call :SetNewVCToolsVersion)
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=${{ matrix.arch }} -host_arch=amd64
           set CC=
           set CXX=
           set Platform=${{ matrix.arch }}
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
+
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
           python -u .\scripts\build.py || exit /b
 
@@ -450,14 +460,17 @@ jobs:
       - name: Build Vistual Studio 2019 (v142)
         run: |
           set VCToolsVersion=14.29
+          set Winsdk=10.0.19041.0
+          set "WindowsSDKVersion=%Winsdk%\"
           if "${{ matrix.arch }}" == "arm64" (call :SetNewVCToolsVersion)
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=${{ matrix.arch }} -host_arch=amd64
           set CC=
           set CXX=
           set Platform=${{ matrix.arch }}
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
+
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
           python -u .\scripts\build.py || exit /b
 
@@ -469,14 +482,17 @@ jobs:
       - name: Build Vistual Studio 2017 (v141)
         run: |
           set VCToolsVersion=14.16
+          set Winsdk=10.0.19041.0
+          set "WindowsSDKVersion=%Winsdk%\"
           if "${{ matrix.arch }}" == "arm64" (call :SetNewVCToolsVersion)
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=${{ matrix.arch }} -host_arch=amd64
           set CC=
           set CXX=
           set Platform=${{ matrix.arch }}
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
+
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
           python -u .\scripts\build.py || exit /b
 
@@ -488,14 +504,17 @@ jobs:
       - name: Build Vistual Studio 2015 (v140)
         run: |
           set VCToolsVersion=14.0
+          set Winsdk=10.0.19041.0
+          set "WindowsSDKVersion=%Winsdk%\"
           if "${{ matrix.arch }}" == "arm64" (call :SetNewVCToolsVersion)
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=${{ matrix.arch }} -host_arch=amd64
           set CC=
           set CXX=
           set Platform=${{ matrix.arch }}
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
+
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
           python -u .\scripts\build.py || exit /b
 
@@ -560,14 +579,17 @@ jobs:
       - name: Build
         run: |
           set VCToolsVersion=14.29
+          set Winsdk=10.0.19041.0
+          set "WindowsSDKVersion=%Winsdk%\"
           if "${{ matrix.arch }}" == "arm64" (call :SetNewVCToolsVersion)
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=${{ matrix.arch }} -host_arch=amd64
           set "CC=%CD%/third_party/llvm-build/Release+Asserts/bin/clang-cl.exe"
           set "CXX=%CD%/third_party/llvm-build/Release+Asserts/bin/clang-cl.exe"
           set Platform=${{ matrix.arch }}
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
+
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
           python -u .\scripts\build.py || exit /b
 
@@ -665,16 +687,19 @@ jobs:
       - name: Build
         run: |
           set VCToolsVersion=14.29
+          set Winsdk=10.0.19041.0
+          set "WindowsSDKVersion=%Winsdk%\"
           if "${{ matrix.arch }}" == "arm64" (call :SetNewVCToolsVersion)
           set vsdevcmd=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
           set "VSCMD_START_DIR=%CD%"
-          call "%vsdevcmd%" -arch=${{ matrix.arch }} -host_arch=amd64
           set CC=
           set CXX=
           set Platform=${{ matrix.arch }}
           set MSVC_CRT_LINKAGE=${{ matrix.crt-linkage }}
 
           set "CLANG_TIDY_EXECUTABLE=%CD%/third_party/llvm-build/Release+Asserts/bin/clang-tidy.exe"
+
+          call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
           python -u .\scripts\build.py || exit /b
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ defaults:
   run:
     shell: bash
 env:
-  CACHE_EPOCH: 10
+  CACHE_EPOCH: 11
 jobs:
   cache-toolchain-win:
     runs-on: windows-2019

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -243,8 +243,8 @@ jobs:
           set VCToolsVersion=
         shell: cmd
       - run: |
-          mv -f ${{ matrix.arch }}-${{ matrix.crt-linkage }}-windows-yass.exe.zip ${{ env.BUNDLE_NAME }}.zip
-          mv -f ${{ matrix.arch }}-${{ matrix.crt-linkage }}-windows-yass.exe-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
+          mv -f yass.zip ${{ env.BUNDLE_NAME }}.zip
+          mv -f yass-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
       - uses: actions/upload-release-asset@v1
         if: ${{ github.event_name == 'release' }}
         env:
@@ -363,8 +363,8 @@ jobs:
           goto :eof
         shell: cmd
       - run: |
-          mv -f ${{ matrix.arch }}-${{ matrix.crt-linkage }}-windows-yass.exe.zip ${{ env.BUNDLE_NAME }}.zip
-          mv -f ${{ matrix.arch }}-${{ matrix.crt-linkage }}-windows-yass.exe-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
+          mv -f yass.zip ${{ env.BUNDLE_NAME }}.zip
+          mv -f yass-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
       - uses: actions/upload-release-asset@v1
         if: ${{ github.event_name == 'release' }}
         env:
@@ -577,8 +577,8 @@ jobs:
           set VCToolsVersion=
         shell: cmd
       - run: |
-          mv -f ${{ matrix.arch }}-${{ matrix.crt-linkage }}-windows-yass.exe.zip ${{ env.BUNDLE_NAME }}.zip
-          mv -f ${{ matrix.arch }}-${{ matrix.crt-linkage }}-windows-yass.exe-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
+          mv -f yass.zip ${{ env.BUNDLE_NAME }}.zip
+          mv -f yass-standalone.zip ${{ env.BUNDLE_NAME }}-standalone.zip
       - uses: actions/upload-release-asset@v1
         if: ${{ github.event_name == 'release' }}
         env:

--- a/scripts/build-xp.bat
+++ b/scripts/build-xp.bat
@@ -30,6 +30,9 @@ call :BuildBoringSSL
 
 python.exe -u .\scripts\build.py || exit /b
 
+move "yass.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
+
 set CC=
 set CXX=
 set Platform=x64
@@ -43,6 +46,9 @@ call "%~dp0callxp-%Platform%.cmd"
 call :BuildBoringSSL
 
 python.exe -u .\scripts\build.py || exit /b
+
+move "yass.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
 
 set CC=
 set CXX=
@@ -58,6 +64,9 @@ call :BuildBoringSSL
 
 python.exe -u .\scripts\build.py || exit /b
 
+move "yass.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
+
 set CC=
 set CXX=
 set Platform=x64
@@ -71,6 +80,9 @@ call "%~dp0callxp-%Platform%.cmd"
 call :BuildBoringSSL
 
 python.exe -u .\scripts\build.py || exit /b
+
+move "yass.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-xp-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
 
 goto :eof
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -36,6 +36,9 @@ set COMPILER_TARGET=i686-pc-windows-msvc
 call :BuildBoringSSL
 python.exe -u .\scripts\build.py || exit /b
 
+move "yass.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
+
 set "VSCMD_START_DIR=%CD%"
 call "%vsdevcmd%" -arch=amd64 -host_arch=amd64
 set CC=
@@ -48,6 +51,9 @@ set COMPILER_TARGET=x86_64-pc-windows-msvc
 call :BuildBoringSSL
 
 python.exe -u .\scripts\build.py || exit /b
+
+move "yass.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
 
 REM Use Visual Studio 2019's toolchain for ARM64 target
 
@@ -66,6 +72,9 @@ call :BuildBoringSSL
 
 python.exe -u .\scripts\build.py || exit /b
 
+move "yass.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
+
 goto :eof
 
 :BuildBoringSSL
@@ -75,6 +84,9 @@ set "CC=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
 set "CXX=%CD%\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe"
 
 call "%~dp0build-boringssl.bat"
+
+move "yass.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
+move "yass-standalone.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
 
 set "CC="
 set "CXX="

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -21,17 +21,20 @@ REM You need to modify the paths below:
 REM Use Visual Studio 2015's toolchain for (x86, x64)
 
 set VCToolsVersion=14.0
+set Winsdk=10.0.19041.0
+set "WindowsSDKVersion=%Winsdk%\"
 
 set vsdevcmd=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat
 
 set "VSCMD_START_DIR=%CD%"
-call "%vsdevcmd%" -arch=x86 -host_arch=amd64
 set CC=
 set CXX=
 set ASM=
 set Platform=x86
 set MSVC_CRT_LINKAGE=dynamic
 set COMPILER_TARGET=i686-pc-windows-msvc
+
+call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
 call :BuildBoringSSL
 python.exe -u .\scripts\build.py || exit /b
@@ -40,7 +43,6 @@ move "yass.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
 move "yass-standalone.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%-standalone.zip"
 
 set "VSCMD_START_DIR=%CD%"
-call "%vsdevcmd%" -arch=amd64 -host_arch=amd64
 set CC=
 set CXX=
 set ASM=
@@ -48,8 +50,9 @@ set Platform=x64
 set MSVC_CRT_LINKAGE=dynamic
 set COMPILER_TARGET=x86_64-pc-windows-msvc
 
-call :BuildBoringSSL
+call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
+call :BuildBoringSSL
 python.exe -u .\scripts\build.py || exit /b
 
 move "yass.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"
@@ -60,7 +63,6 @@ REM Use Visual Studio 2019's toolchain for ARM64 target
 set VCToolsVersion=14.29
 
 set "VSCMD_START_DIR=%CD%"
-call "%vsdevcmd%" -arch=arm64 -host_arch=amd64
 set CC=
 set CXX=
 set ASM=
@@ -68,8 +70,9 @@ set Platform=arm64
 set MSVC_CRT_LINKAGE=dynamic
 set COMPILER_TARGET=arm64-pc-windows-msvc
 
-call :BuildBoringSSL
+call "%vsdevcmd%" -arch=%Platform% -host_arch=amd64 -winsdk=%Winsdk%
 
+call :BuildBoringSSL
 python.exe -u .\scripts\build.py || exit /b
 
 move "yass.zip" "yass-msvc-release-%Platform%-%MSVC_CRT_LINKAGE%.zip"

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -688,12 +688,8 @@ def archive_files(output, paths = []):
 
 
 def postbuild_archive():
-  if sys.platform == 'win32':
-    src = get_app_name()
-    dst = '%s-%s-windows-%s' % (DEFAULT_ARCH, DEFAULT_MSVC_CRT_LINKAGE, get_app_name())
-  else:
-    src = get_app_name()
-    dst = '%s-%s' % (sys.platform, get_app_name())
+  src = get_app_name()
+  dst = APP_NAME
 
   archive = dst + '.zip'
   full_archive = dst + '-standalone.zip'

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -385,6 +385,8 @@ def check_universal_build_dylib_darwin(lib_path):
 
 def _postbuild_copy_libraries_win32():
   dlls = get_dependencies_recursively(get_app_name())
+  # for pretty output
+  dlls.sort()
   for dll in dlls:
     print('copying depended dll file: %s' % dll)
     shutil.copyfile(dll, os.path.basename(dll))

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -283,9 +283,11 @@ def get_dependencies_by_dumpbin(path):
   ### TODO should we support Windows SDK 7.0A or 8.1?
   ### Please note The UCRT files are not redistributable for ARM64 Win32.
   ### https://chromium.googlesource.com/chromium/src/+/lkgr/build/win/BUILD.gn
+  ### C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\ucrt
   ### C:\Program Files (x86)\Windows Kits\10\Redist\10.0.19041.0\ucrt\DLLS\x86
   ### C:\Program Files (x86)\Windows Kits\10\ExtensionSDKs\Microsoft.UniversalCRT.Debug\10.0.19041.0\Redist\Debug\x86
   search_dirs.extend([
+    os.path.join(sdk_base_dir, 'bin', sdk_version, DEFAULT_ARCH, 'ucrt'),
     os.path.join(sdk_base_dir, 'Redist', sdk_version, 'ucrt', 'DLLS',
                  DEFAULT_ARCH),
     os.path.join(sdk_base_dir, 'ExtensionSDKs', 'Microsoft.UniversalCRT.Debug',


### PR DESCRIPTION
It is a known issue that ARM64 winsdk doesn't contain redist files, so it should be fine.