### PR TITLE
win: extract xp-required ucrtbase.dll from vcredist

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           path: |
             third_party/llvm-build/Release+Asserts
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -71,7 +71,7 @@ jobs:
         with:
           path: |
             third_party/boringssl/libcrypto.a
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.arch }}-build-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-boringssl-build-${{ matrix.arch }}-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: "Install dependency: clang and clang-tidy"
         run: |
           if [ ! -d third_party/llvm-build/Release+Asserts ]; then
@@ -114,7 +114,7 @@ jobs:
         with:
           path: |
             third_party/llvm-build/Release+Asserts
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -123,7 +123,7 @@ jobs:
         with:
           path: |
             third_party/boringssl/libcrypto.a
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.arch }}-build-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-boringssl-build-${{ matrix.arch }}-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Populate depedencies
         run: sudo apt-get install -y cmake ninja-build libgtk-3-dev libgtkmm-3.0-dev
       - name: Build
@@ -159,7 +159,7 @@ jobs:
         with:
           path: |
             third_party/llvm-build/Release+Asserts
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -168,7 +168,7 @@ jobs:
         with:
           path: |
             third_party/boringssl/libcrypto.a
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.arch }}-build-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-boringssl-build-${{ matrix.arch }}-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Populate depedencies
         run: sudo apt-get install -y cmake ninja-build libgtk-3-dev libgtkmm-3.0-dev
       - name: Build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: |
             third_party/llvm-build/Release+Asserts
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -41,7 +41,7 @@ jobs:
             third_party/boringssl/libcrypto.a
             third_party/boringssl/x64-libcrypto.a
             third_party/boringssl/arm64-libcrypto.a
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.arch }}-build-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-boringssl-build-${{ matrix.arch }}-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: "Install dependency: clang and clang-tidy"
         run: |
           if [ ! -d third_party/llvm-build/Release+Asserts ]; then
@@ -114,7 +114,7 @@ jobs:
         with:
           path: |
             third_party/llvm-build/Release+Asserts
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -125,7 +125,7 @@ jobs:
             third_party/boringssl/libcrypto.a
             third_party/boringssl/x64-libcrypto.a
             third_party/boringssl/arm64-libcrypto.a
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.arch }}-build-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-boringssl-build-${{ matrix.arch }}-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Populate depedencies
         run: brew install ninja cmake
       - name: Populate depedencies (PyObjc)
@@ -185,7 +185,7 @@ jobs:
         with:
           path: |
             third_party/llvm-build/Release+Asserts
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -196,7 +196,7 @@ jobs:
             third_party/boringssl/libcrypto.a
             third_party/boringssl/x64-libcrypto.a
             third_party/boringssl/arm64-libcrypto.a
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.arch }}-build-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-boringssl-build-${{ matrix.arch }}-${{ hashFiles('**\boringssl.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Populate depedencies
         run: brew install ninja cmake
       - name: Populate depedencies (PyObjc)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
             third_party/nasm
             third_party/llvm-build/Release+Asserts
             third_party/vcredist
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ matrix.crt-linkage }}-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
           IFS=" " read -r -a array <<< $VCPKG_DEPS
@@ -50,7 +50,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/buildtrees
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.crt-linkage }}-build-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-vcpkg-build-${{ matrix.crt-linkage }}-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -219,7 +219,7 @@ jobs:
             third_party/nasm
             third_party/llvm-build/Release+Asserts
             third_party/vcredist
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ matrix.crt-linkage }}-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
           IFS=" " read -r -a array <<< $VCPKG_DEPS
@@ -234,7 +234,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/buildtrees
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.crt-linkage }}-build-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-vcpkg-build-${{ matrix.crt-linkage }}-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -328,7 +328,7 @@ jobs:
             third_party/nasm
             third_party/llvm-build/Release+Asserts
             third_party/vcredist
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ matrix.crt-linkage }}-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
           IFS=" " read -r -a array <<< $VCPKG_DEPS
@@ -343,7 +343,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/buildtrees
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.crt-linkage }}-build-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-vcpkg-build-${{ matrix.crt-linkage }}-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -448,7 +448,7 @@ jobs:
             third_party/nasm
             third_party/llvm-build/Release+Asserts
             third_party/vcredist
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ matrix.crt-linkage }}-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
           IFS=" " read -r -a array <<< $VCPKG_DEPS
@@ -463,7 +463,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/buildtrees
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.crt-linkage }}-build-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-vcpkg-build-${{ matrix.crt-linkage }}-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -568,7 +568,7 @@ jobs:
             third_party/nasm
             third_party/llvm-build/Release+Asserts
             third_party/vcredist
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ matrix.crt-linkage }}-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
           IFS=" " read -r -a array <<< $VCPKG_DEPS
@@ -583,7 +583,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/buildtrees
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.crt-linkage }}-build-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-vcpkg-build-${{ matrix.crt-linkage }}-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock
@@ -677,7 +677,7 @@ jobs:
             third_party/nasm
             third_party/llvm-build/Release+Asserts
             third_party/vcredist
-          key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-toolchain-build-${{ matrix.crt-linkage }}-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
           IFS=" " read -r -a array <<< $VCPKG_DEPS
@@ -692,7 +692,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/buildtrees
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
-          key: toolchain-cache-${{ runner.os }}-${{ matrix.crt-linkage }}-build-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
+          key: toolchain-cache-${{ runner.os }}-vcpkg-build-${{ matrix.crt-linkage }}-${{ hashFiles('**\vcpkg.lock') }}-v${{ env.CACHE_EPOCH }}
       - name: Get boringssl commit
         run: |
           git submodule status third_party/boringssl >> boringssl.lock

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ defaults:
   run:
     shell: bash
 env:
-  CACHE_EPOCH: 11
+  CACHE_EPOCH: 12
 jobs:
   cache-toolchain-win:
     runs-on: windows-2019
@@ -28,12 +28,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - name: Cache clang and nasm
+      - name: Cache clang, nasm and extracted vcredist files
         uses: actions/cache@v2
         with:
           path: |
             third_party/nasm
             third_party/llvm-build/Release+Asserts
+            third_party/vcredist
           key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
@@ -77,6 +78,20 @@ jobs:
             CLANG_REVISION=$(< CLANG_REVISION)
             curl https://commondatastorage.googleapis.com/chromium-browser-clang/$CLANG_ARCH/clang-$CLANG_REVISION.tgz | tar xzf - -C third_party/llvm-build/Release+Asserts
             curl https://commondatastorage.googleapis.com/chromium-browser-clang/$CLANG_ARCH/clang-tidy-$CLANG_REVISION.tgz | tar xzf - -C third_party/llvm-build/Release+Asserts
+          fi
+      - name: "Install dependency: extracted vcredist runtime (v140)"
+        run: |
+          if [ ! -d third_party/vcredist ]; then
+            mkdir -p third_party/vcredist
+            curl -L -O https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip
+            "/c/Program Files/7-Zip/7z.exe" x -owix311 wix311-binaries.zip
+            wix311/dark.exe "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\1033\vcredist_x86.exe" -x tmp
+            "/c/Program Files/7-Zip/7z.exe" x "-othird_party\vcredist\x86" "tmp\AttachedContainer\packages\vcRuntimeMinimum_x86\cab1.cab"
+            python -c "import os; os.chdir('third_party/vcredist/x86'); dlls = os.listdir('.'); [ os.rename(dll, dll.replace('_', '-')) for dll in dlls ];"
+            wix311/dark.exe "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\1033\vcredist_x64.exe" -x tmp
+            "/c/Program Files/7-Zip/7z.exe" x "-othird_party\vcredist\x64" "tmp\AttachedContainer\packages\vcRuntimeMinimum_amd64\cab1.cab"
+            python -c "import os; os.chdir('third_party/vcredist/x64'); dlls = os.listdir('.'); [ os.rename(dll, dll.replace('_', '-')) for dll in dlls ];"
+            rm -rf wix311* tmp
           fi
       - name: "Install dependency: boringssl (x86 slice)"
         shell: cmd
@@ -197,12 +212,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - name: Cache clang and nasm
+      - name: Cache clang, nasm and extracted vcredist files
         uses: actions/cache@v2
         with:
           path: |
             third_party/nasm
             third_party/llvm-build/Release+Asserts
+            third_party/vcredist
           key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
@@ -305,12 +321,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - name: Cache clang and nasm
+      - name: Cache clang, nasm and extracted vcredist files
         uses: actions/cache@v2
         with:
           path: |
             third_party/nasm
             third_party/llvm-build/Release+Asserts
+            third_party/vcredist
           key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
@@ -424,12 +441,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - name: Cache clang and nasm
+      - name: Cache clang, nasm and extracted vcredist files
         uses: actions/cache@v2
         with:
           path: |
             third_party/nasm
             third_party/llvm-build/Release+Asserts
+            third_party/vcredist
           key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
@@ -543,12 +561,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - name: Cache clang and nasm
+      - name: Cache clang, nasm and extracted vcredist files
         uses: actions/cache@v2
         with:
           path: |
             third_party/nasm
             third_party/llvm-build/Release+Asserts
+            third_party/vcredist
           key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |
@@ -651,12 +670,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - name: Cache clang and nasm
+      - name: Cache clang, nasm and extracted vcredist files
         uses: actions/cache@v2
         with:
           path: |
             third_party/nasm
             third_party/llvm-build/Release+Asserts
+            third_party/vcredist
           key: toolchain-cache-${{ runner.os }}-build-${{ hashFiles('CLANG_REVISION') }}-v${{ env.CACHE_EPOCH }}
       - name: Get vcpkg commit
         run: |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,21 @@ yass, or Yet Another Shadow Socket is lightweight and secure http/socks4/socks5 
 ### Legacy Ubuntu 16.04
 <img width="484" alt="snapshot-winxp" src="https://user-images.githubusercontent.com/54673341/151591522-d86248f7-763f-432e-9dd8-fd16317d477b.png">
 
-## Notes on Windows 7, Windows 8 and Windows 8.1
+## Running on Windows
+
+TLDR' if you running `yass.exe` ends with missing dlls error, please download
+standalone packages (slightly larger) or install Visual C++ Redistributable Package
+below. The required UCRT (Universal C Runtime) is bundled as well.
+
+Also the packages named "static" are also runnable except you are probably
+running without the updated VCRuntime/CRT (hotfixes or upgrade etc).
+
+### Notes on Windows 10
+
+Visual C++ Redistributable Package is part of Operating System. You should run
+yass.exe without problems.
+
+### Notes on Windows 7, Windows 8 and Windows 8.1
 
 If you run Windows prior to Windows 10, Visual C++ Runtime Files may be [required][latest-supported-vc-redist]:
 
@@ -55,7 +69,10 @@ ARM64 | https://aka.ms/vs/17/release/vc_redist.arm64.exe | Permalink for latest 
 X86 | https://aka.ms/vs/17/release/vc_redist.x86.exe | Permalink for latest supported x86 version
 X64 | https://aka.ms/vs/17/release/vc_redist.x64.exe | Permalink for latest supported x64 version. The X64 redistributable package contains both ARM64 and X64 binaries. This package makes it easy to install required Visual C++ ARM64 binaries when the X64 redistributable is installed on an ARM64 device.
 
-## Notes on Windows XP
+### Notes on Windows XP
+
+There is no standalone UCRT with Windows XP, so you should stick to the one
+bundled inside Visual C++ Redistributable Package.
 
 According to [Microsoft][latest-supported-vc-redist], the last version of the Visual C++ Redistributable that
 works on Windows XP shipped in Visual Studio 2019 version 16.7 (file versions starting with 14.27).

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -229,7 +229,7 @@ def _get_win32_search_paths():
   sdk_base_dir= os.getenv('WindowsSdkDir')
 
   ### Search Path (UCRT)
-  ### TODO should we support Windows SDK 7.0A or 8.1?
+  ###
   ### Please note The UCRT files are not redistributable for ARM64 Win32.
   ### https://chromium.googlesource.com/chromium/src/+/lkgr/build/win/BUILD.gn
   ### C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\ucrt
@@ -242,6 +242,15 @@ def _get_win32_search_paths():
     os.path.join(sdk_base_dir, 'ExtensionSDKs', 'Microsoft.UniversalCRT.Debug',
                  sdk_version, 'Redist', 'Debug', DEFAULT_ARCH),
   ])
+
+  ### Fallback search path for XP (v140)
+  ### Refer to #27, https://github.com/Chilledheart/yass/issues/27
+  ### $project_root\third_party\vcredist\x86
+  if vctools_version >= 14.00 and vctools_version < 14.10:
+    search_dirs.extend([
+      os.path.join(os.path.dirname(os.path.realpath(__file__)), '..',
+                   'third_party', 'vcredist', DEFAULT_ARCH)
+    ])
   return search_dirs
 
 """


### PR DESCRIPTION
Fixes #27.

VCRedist ships a XP-compatible ucrt, use them if possible.

It seems working:

copying depended dll file:
  --- C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\CONCRT140.dll
  --- C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\MSVCP140.dll
  --- C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\VCRUNTIME140.dll
  --- C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.MFC\mfc140u.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-convert-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-environment-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-filesystem-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-heap-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-locale-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-math-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-multibyte-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-runtime-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-stdio-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-string-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-time-l1-1-0.dll
  --- C:\yass\scripts\..\third_party\vcredist\x64\api-ms-win-crt-utility-l1-1-0.dll