### PR TITLE
update .clang-tidy spec

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,15 +1,23 @@
 ---
+  # TODO(crbug.com/1282228): reenable google-readability-casting once it no
+  # longer has as many false-positives.
+  # TODO(crbug.com/1406869): reenable modernize-use-default-member-init once
+  # C++20 is everywhere; it recommends using default member init for bit fields,
+  # which is C++20-only.
   Checks:          '-*,
                     bugprone-argument-comment,
+                    bugprone-assert-side-effect,
                     bugprone-dangling-handle,
                     bugprone-inaccurate-erase,
                     bugprone-string-constructor,
                     bugprone-string-integer-assignment,
+                    bugprone-undefined-memory-manipulation,
                     bugprone-unused-raii,
                     bugprone-use-after-move,
                     google-build-explicit-make-pair,
                     google-explicit-constructor,
-                    google-readability-casting,
+                    misc-misleading-identifier,
+                    misc-homoglyph,
                     modernize-avoid-bind,
                     modernize-concat-nested-namespaces,
                     modernize-loop-convert,
@@ -19,7 +27,6 @@
                     modernize-replace-random-shuffle,
                     modernize-shrink-to-fit,
                     modernize-use-bool-literals,
-                    modernize-use-default-member-init,
                     modernize-use-emplace,
                     modernize-use-equals-default,
                     modernize-use-equals-delete,
@@ -31,15 +38,29 @@
   # Only include headers directly in src.
   HeaderFilterRegex: 'src/[^/]*$'
   CheckOptions:
+    - key:          bugprone-assert-side-effect.AssertMacros
+      value:        assert,DCHECK
     - key:          bugprone-dangling-handle.HandleClasses
       value:        ::std::basic_string_view;::std::span;::absl::string_view;::base::BasicStringPiece;::base::span
     - key:          bugprone-string-constructor.StringNames
-      value:        ::std::basic_string;::std::basic_string_view;::base::BasicStringPiece
+      value:        ::std::basic_string;::std::basic_string_view;::base::BasicStringPiece;::absl::string_view
     - key:          modernize-use-default-member-init.UseAssignment
+      value:        1
+    # crbug.com/1342136, crbug.com/1343915: At times, this check makes
+    # suggestions that break builds. Safe mode allows us to sidestep that.
+    - key:          modernize-use-transparent-functors.SafeMode
       value:        1
     # This relaxes modernize-use-emplace in some cases; we might want to make it
     # more aggressive in the future. See discussion on
     # https://groups.google.com/a/chromium.org/g/cxx/c/noMMTNYiM0w .
     - key:          modernize-use-emplace.IgnoreImplicitConstructors
       value:        1
+    # crbug.com/1420969, crbug.com/1421042: Tricium's `show fix` button isn't
+    # working, which leads to devs thinking that clang-tidy is suggesting C++20
+    # constructs in some cases. Until fixes can be surfaced to show that
+    # `base::Reversed` is encouraged, just turn reverse ranges off entirely.
+    # TODO(crbug.com/1404958): alternatively, remove these once C++20 is
+    # everywhere.
+    - key:          modernize-loop-convert.UseCxx20ReverseRanges
+      value:        false
 ...

--- a/src/core/logging.cpp
+++ b/src/core/logging.cpp
@@ -2736,9 +2736,10 @@ static void VLOG2Initializer() {
       tail = info;
     }
     // Skip past this entry
-    vmodule = strchr(sep, ',');
-    if (vmodule == nullptr)
+    const char *vmodule_ptr = strchr(sep, ',');
+    if (vmodule_ptr == nullptr)
       break;
+    vmodule = absl::string_view(vmodule_ptr);
     vmodule.remove_prefix(1);
   }
   if (head) {  // Put them into the list at the head:


### PR DESCRIPTION
  from https://chromium.googlesource.com/chromium/src/+log/refs/heads/main/.clang-tidy

  17c8e4f mb_config: stop forcing -std=c++17 for tidy builders by George Burgess IV · 7 weeks ago
  8899257 clang-tidy: disable reverse iterator suggestions by George Burgess IV · 4 months ago
  d4f38b67 clang-tidy: Add misc-misleading-identifier and misc-homoglyph by Ryan Beltran · 5 months ago
  0897801 clang-tidy: don't suggest c++20's reverse_view. by George Burgess IV · 6 months ago
  387e323 Enable bugprone-undefined-memory-manipulation clang-tidy warning. by Daniel Cheng · 7 months ago
  a01425e4 clang-tidy: turn on SafeMode for modernize-use-transparent-functors by George Burgess IV · 12 months ago
  4f18f3f clang-tidy: add absl::string_view to stringy-types list by George Burgess IV · 12 months ago
  f828a224 clang-tidy: temporarily disable google-readability-casting by George Burgess IV · 1 year, 2 months ago
  9f7338f clang-tidy: enable bugprone-assert-side-effect by George Burgess IV · 1 year, 4 months ago
  efca412 Allow C++17's nested namespaces by Avi Drissman · 1 year, 6 months ago
  25a5358 Add absl::string_view to dangling HandleClasses by Peter Boström · 1 year, 10 months ago