### PR TITLE
tests: workaround with curl localhost resolving

### DIFF
--- a/src/ss_test.cpp
+++ b/src/ss_test.cpp
@@ -383,10 +383,13 @@ class SsEndToEndTest : public ::testing::Test {
     ASSERT_TRUE(curl) << "curl initial failure";
     std::string url = "http://localhost:" + std::to_string(content_provider_endpoint_.port());
     // TODO A bug inside curl that it doesn't respect IPRESOLVE_V6
-    // https://github.com/curl/curl/issues/11458
-    if (absl::GetFlag(FLAGS_ipv6_mode) &&
-        absl::GetFlag(FLAGS_proxy_type) == "socks5") {
-      url = "http://[::1]:" + std::to_string(content_provider_endpoint_.port());
+    // https://github.com/curl/curl/issues/11465
+    if (absl::GetFlag(FLAGS_proxy_type) == "socks5") {
+      if (absl::GetFlag(FLAGS_ipv6_mode)) {
+        url = "http://[::1]:" + std::to_string(content_provider_endpoint_.port());
+      } else {
+        url = "http://127.0.0.1:" + std::to_string(content_provider_endpoint_.port());
+      }
     }
     if (VLOG_IS_ON(1)) {
       curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
After curl resolves localhost by itself, IPv4 address came first until recently. For most modern resolver, IPv6 address comes first.

see more at: https://github.com/curl/curl/issues/11465
and: https://daniel.haxx.se/blog/2021/05/31/curl-localhost-as-a-local-host/