### PR TITLE
riscv: fix mismatch float abi warning

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -40,6 +40,13 @@ ifneq ($(filter clang,$(DEB_BUILD_PROFILES)),)
 override_dh_auto_configure: ASMFLAGS += -target ${DEB_HOST_GNU_TYPE} -ccc-gcc-name ${DEB_HOST_GNU_TYPE}-gcc
 override_dh_auto_configure: CFLAGS += -target ${DEB_HOST_GNU_TYPE} -ccc-gcc-name ${DEB_HOST_GNU_TYPE}-gcc
 override_dh_auto_configure: CXXFLAGS += -target ${DEB_HOST_GNU_TYPE} -ccc-gcc-name ${DEB_HOST_GNU_TYPE}-g++
+ifneq ($(filter riscv64,$(DEB_HOST_GNU_CPU)),)
+# According to the ISA spec definition rv64gc is rv64imafdc_zicsr_zifencei and
+# rv64imafdc is rv64imafdc_zicsr, see https://github.com/riscv-collab/riscv-gcc/issues/344
+override_dh_auto_configure: ASMFLAGS += -march=rv64gc -mabi=lp64d
+override_dh_auto_configure: CFLAGS += -march=rv64gc -mabi=lp64d
+override_dh_auto_configure: CXXFLAGS += -march=rv64gc -mabi=lp64d
+endif
 endif
 
 ifneq ($(filter cross,$(DEB_BUILD_PROFILES)),)

--- a/debian/rules
+++ b/debian/rules
@@ -46,6 +46,8 @@ ifneq ($(filter riscv64,$(DEB_HOST_GNU_CPU)),)
 override_dh_auto_configure: ASMFLAGS += -march=rv64gc -mabi=lp64d
 override_dh_auto_configure: CFLAGS += -march=rv64gc -mabi=lp64d
 override_dh_auto_configure: CXXFLAGS += -march=rv64gc -mabi=lp64d
+# lto mess with d extension support
+CMAKE_OPTIONS += -DENABLE_LTO=off
 endif
 endif
 


### PR DESCRIPTION
Fixes #345.