### PR TITLE
mbedtls: adjust for ss stream protocol

### DIFF
--- a/src/core/cipher.hpp
+++ b/src/core/cipher.hpp
@@ -114,6 +114,7 @@ class cipher {
                           size_t plaintext_size,
                           IOBuf* ciphertext) const;
 
+  void set_key_stream(const uint8_t* nonce, size_t nonce_len);
   void set_key_aead(const uint8_t* salt, size_t salt_len);
 
  private:

--- a/src/crypto/aead_base_decrypter.cpp
+++ b/src/crypto/aead_base_decrypter.cpp
@@ -82,6 +82,10 @@ const uint8_t* AeadBaseDecrypter::GetKey() const {
   return key_;
 }
 
+const uint8_t* AeadBaseDecrypter::GetIV() const {
+  return iv_;
+}
+
 const uint8_t* AeadBaseDecrypter::GetNoncePrefix() const {
   return iv_;
 }

--- a/src/crypto/aead_base_decrypter.hpp
+++ b/src/crypto/aead_base_decrypter.hpp
@@ -29,6 +29,7 @@ class AeadBaseDecrypter : public Decrypter {
   size_t GetTagSize() const override;
 
   const uint8_t* GetKey() const override;
+  const uint8_t* GetIV() const override;
   const uint8_t* GetNoncePrefix() const override;
 
  protected:

--- a/src/crypto/aead_base_encrypter.cpp
+++ b/src/crypto/aead_base_encrypter.cpp
@@ -81,6 +81,10 @@ const uint8_t* AeadBaseEncrypter::GetKey() const {
   return key_;
 }
 
+const uint8_t* AeadBaseEncrypter::GetIV() const {
+  return iv_;
+}
+
 const uint8_t* AeadBaseEncrypter::GetNoncePrefix() const {
   return iv_;
 }

--- a/src/crypto/aead_base_encrypter.hpp
+++ b/src/crypto/aead_base_encrypter.hpp
@@ -30,6 +30,7 @@ class AeadBaseEncrypter : public Encrypter {
   size_t GetTagSize() const override;
 
   const uint8_t* GetKey() const override;
+  const uint8_t* GetIV() const override;
   const uint8_t* GetNoncePrefix() const override;
 
  protected:

--- a/src/crypto/aead_mbedtls_decrypter.cpp
+++ b/src/crypto/aead_mbedtls_decrypter.cpp
@@ -65,11 +65,6 @@ bool AeadMbedtlsDecrypter::DecryptPacket(uint64_t packet_number,
   uint8_t nonce[kMaxNonceSize] = {};
   memcpy(nonce, iv_, nonce_size_);
 
-  // for libsodium, packet number is written ahead
-  PacketNumberToNonceSodium(nonce, nonce_size_, packet_number);
-
-  DumpHex("DE-NONCE", nonce, nonce_size_);
-
   if (mbedtls_cipher_update(evp_,
                             reinterpret_cast<const uint8_t*>(ciphertext),
                             ciphertext_len,

--- a/src/crypto/aead_mbedtls_encrypter.cpp
+++ b/src/crypto/aead_mbedtls_encrypter.cpp
@@ -82,11 +82,6 @@ bool AeadMbedtlsEncrypter::EncryptPacket(uint64_t packet_number,
   uint8_t nonce[kMaxNonceSize] = {};
   memcpy(nonce, iv_, nonce_size_);
 
-  // for libsodium, packet number is written ahead
-  PacketNumberToNonceSodium(nonce, nonce_size_, packet_number);
-
-  DumpHex("EN-NONCE", nonce, nonce_size_);
-
   *output_length = max_output_length;
 
   if (!Encrypt(nonce, nonce_size_, associated_data, associated_data_len,

--- a/src/crypto/decrypter.hpp
+++ b/src/crypto/decrypter.hpp
@@ -69,6 +69,7 @@ class Decrypter : public Crypter {
 
   // For use by unit tests only.
   virtual const uint8_t* GetKey() const = 0;
+  virtual const uint8_t* GetIV() const = 0;
   virtual const uint8_t* GetNoncePrefix() const = 0;
 
 #if 0

--- a/src/crypto/encrypter.hpp
+++ b/src/crypto/encrypter.hpp
@@ -58,6 +58,7 @@ class Encrypter : public Crypter {
 
   // For use by unit tests only.
   virtual const uint8_t* GetKey() const = 0;
+  virtual const uint8_t* GetIV() const = 0;
   virtual const uint8_t* GetNoncePrefix() const = 0;
 };
 


### PR DESCRIPTION
tested with aes-128-cfb cipher under https://github.com/shadowsocks/shadowsocks-libev/blob/d83ace0f0d9c05656c13d66aa4a449bf70143254/src/stream.c.