### PR TITLE
deb: add missing pkg-config-crosswrapper for pkgconf

### DIFF
--- a/.github/workflows/releases-deb.yml
+++ b/.github/workflows/releases-deb.yml
@@ -30,7 +30,7 @@ on:
   release:
     types: [published]
 env:
-  CACHE_EPOCH: 116v2
+  CACHE_EPOCH: 116v3
   GOPROXY: direct
   DH_QUIET: 1
 jobs:
@@ -189,6 +189,11 @@ jobs:
             apt-get install -y dpkg-cross pkg-config gcc-$HOST_GNU_TYPE g++-$HOST_GNU_TYPE libc6:${{ env.HOST_ARCH }} libstdc++6:${{ env.HOST_ARCH }} linux-libc-dev:${{ env.HOST_ARCH }}
           sudo schroot --chroot "source:${{ env.HOST_DISTRO }}-${{ env.BUILD_ARCH }}-${{ env.HOST_ARCH }}" --user root -- \
             ln -sf /usr/share/pkg-config-crosswrapper /usr/bin/${HOST_GNU_TYPE}-pkg-config
+      - name: Populate sysroot (crosscompile toolchain, for bookworm and later distro)
+        if: ${{ steps.schroot-cache.outputs.cache-hit != 'true' && env.HOST_ARCH != 'i386' && env.HOST_ARCH != 'amd64' }}
+        run: |
+          sudo schroot --chroot "source:${{ env.HOST_DISTRO }}-${{ env.BUILD_ARCH }}-${{ env.HOST_ARCH }}" --user root -- \
+            bash -c "[ ! -f /usr/share/pkg-config-crosswrapper ] && cp -v $PWD/debian/pkg-config-crosswrapper /usr/share/pkg-config-crosswrapper || :"
       - name: Populate sysroot (standard toolchain)
         if: ${{ steps.schroot-cache.outputs.cache-hit != 'true' }}
         run: |

--- a/debian/pkg-config-crosswrapper
+++ b/debian/pkg-config-crosswrapper
@@ -1,0 +1,37 @@
+#! /bin/sh
+# pkg-config wrapper for cross-building
+# Sets pkg-config search path to search multiarch and historical cross-compiling paths.
+
+# If the user has already set PKG_CONFIG_LIBDIR, believe it (even if empty):
+# it's documented to be an override
+if [ x"${PKG_CONFIG_LIBDIR+set}" = x ]; then
+  # GNU triplet for the compiler, e.g. i486-linux-gnu for Debian i386,
+  # i686-linux-gnu for Ubuntu i386
+  basename="`basename "$0"`"
+  triplet="${basename%-pkg-config}"
+  # Normalized multiarch path if any, e.g. i386-linux-gnu for i386
+  multiarch="`dpkg-architecture -t"${triplet}" -qDEB_HOST_MULTIARCH 2>/dev/null`"
+
+  PKG_CONFIG_LIBDIR="/usr/local/${triplet}/lib/pkgconfig"
+  # For a native build we would also want to append /usr/local/lib/pkgconfig
+  # at this point; but this is a cross-building script, so don't
+  PKG_CONFIG_LIBDIR="$PKG_CONFIG_LIBDIR:/usr/local/share/pkgconfig"
+
+  if [ -n "$multiarch" ]; then
+    PKG_CONFIG_LIBDIR="/usr/local/lib/${multiarch}/pkgconfig:$PKG_CONFIG_LIBDIR"
+    PKG_CONFIG_LIBDIR="$PKG_CONFIG_LIBDIR:/usr/lib/${multiarch}/pkgconfig"
+  fi
+
+  PKG_CONFIG_LIBDIR="$PKG_CONFIG_LIBDIR:/usr/${triplet}/lib/pkgconfig"
+  # For a native build we would also want to append /usr/lib/pkgconfig
+  # at this point; but this is a cross-building script, so don't
+  # If you want to allow use of un-multiarched -dev packages for crossing
+  # (at the risk of finding build-arch stuff you didn't want, if not in a clean chroot)
+  # Uncomment the next line:
+  # PKG_CONFIG_LIBDIR="$PKG_CONFIG_LIBDIR:/usr/lib/pkgconfig"
+  PKG_CONFIG_LIBDIR="$PKG_CONFIG_LIBDIR:/usr/share/pkgconfig"
+
+  export PKG_CONFIG_LIBDIR
+fi
+
+exec pkg-config $@


### PR DESCRIPTION
From debian bookworm and ubuntu lunar,
there is no pkg-config-crosswrapper because pkgconf replaces old pkg-config.