### PR TITLE
linux: roll sysroots with gtk4 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,8 @@ option(ENABLE_LTO "Enable build with LTO" ON)
 option(ENABLE_LLD "Enable build with LLD" ON)
 option(ENABLE_GOLD "Enable build with GOLD" ON)
 
+option(USE_GTK4 "Build with gtk4 if possible (GUI)" ON)
+
 # Dynamic users are supported from version 235
 # see https://0pointer.net/blog/dynamic-users-with-systemd.html
 if (USE_OLD_SYSTEMD_SERVICE)
@@ -2127,17 +2129,18 @@ elseif (GUI)
       set(GUI off)
     endif()
 
-    # fix up for loongarch gtk support
+    # fix up for loongarch64 gtk support
     # see https://github.com/microcai/gentoo-zh/pull/4486
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "loongarch64")
       message(STATUS "Blacklist gtk4 for loongarch64 target")
-      set(BLACKLIST_GTK4 ON)
-    else()
-      set(BLACKLIST_GTK4 OFF)
+      set(USE_GTK4 OFF)
     endif()
 
-    pkg_check_modules(GTK4 gtk4)
-    if (GTK4_FOUND AND NOT BLACKLIST_GTK4)
+    if (GUI AND USE_GTK4)
+      pkg_check_modules(GTK4 gtk4)
+    endif()
+
+    if (GUI AND USE_GTK4 AND GTK4_FOUND)
       set(GUI_FLAVOUR "gtk4")
       set(GUI_OTHER_FLAGS -Wno-deprecated-declarations)
 
@@ -2157,7 +2160,7 @@ elseif (GUI)
         set(GUI_LIBRARY_DIRS ${GTK4_LIBRARY_DIRS} ${FONTCONFIG_LIBRARY_DIRS})
         set(GUI_LIBRARIES ${GTK4_LIBRARIES} ${FONTCONFIG_LIBRARIES})
       endif()
-    else()
+    elseif (GUI)
       pkg_check_modules(GTK gtk+-3.0)
       set(GUI_FLAVOUR "gtk3")
       set(GUI_OTHER_FLAGS -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED)

--- a/scripts/sysroots.json
+++ b/scripts/sysroots.json
@@ -1,49 +1,49 @@
 {
     "bullseye_amd64": {
         "Key": "20230611T210420Z-2",
-        "Sha1Sum": "4c00ba2ad61ca7cc39392f192aa39420e086777c",
+        "Sha1Sum": "ec989b96c5f1e235182e5f2a5c9d23b3eb4101e0",
         "SysrootDir": "debian_bullseye_amd64-sysroot",
         "Tarball": "debian_bullseye_amd64_sysroot.tar.xz",
         "URL": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain"
     },
     "bullseye_arm64": {
         "Key": "20230611T210420Z-2",
-        "Sha1Sum": "41a6c8dec4c4304d6509e30cbaf9218dffb4438e",
+        "Sha1Sum": "f65e4d81b81d19f4354ed1bb22afeb1f3949a446",
         "SysrootDir": "debian_bullseye_arm64-sysroot",
         "Tarball": "debian_bullseye_arm64_sysroot.tar.xz",
         "URL": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain"
     },
     "bullseye_armel": {
         "Key": "20230611T210420Z-2",
-        "Sha1Sum": "bcff5c5a4060f3be7bff28aa9ff28c100b70a858",
+        "Sha1Sum": "e27b133d817fd141d6eacdc7db749dfaf7ae6b41",
         "SysrootDir": "debian_bullseye_armel-sysroot",
         "Tarball": "debian_bullseye_armel_sysroot.tar.xz",
         "URL": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain"
     },
     "bullseye_armhf": {
         "Key": "20230611T210420Z-2",
-        "Sha1Sum": "c153bf1027a67eec0f6ea2efa190e29c9c06e603",
+        "Sha1Sum": "023be791a65b04d6201f2d60052742683230050b",
         "SysrootDir": "debian_bullseye_armhf-sysroot",
         "Tarball": "debian_bullseye_armhf_sysroot.tar.xz",
         "URL": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain"
     },
     "bullseye_i386": {
         "Key": "20230611T210420Z-2",
-        "Sha1Sum": "cfba9004de1ace04f9604c13c30abad3be90e58f",
+        "Sha1Sum": "0997cb9c140089cee06252fcb656042526cdac8e",
         "SysrootDir": "debian_bullseye_i386-sysroot",
         "Tarball": "debian_bullseye_i386_sysroot.tar.xz",
         "URL": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain"
     },
     "bullseye_mips64el": {
         "Key": "20230611T210420Z-2",
-        "Sha1Sum": "3ce49d1c6b5fef17ad512f2d663a175829ae0b72",
+        "Sha1Sum": "868d8bfdbf9bd69ea0013fed4a97fa44fbc98a21",
         "SysrootDir": "debian_bullseye_mips64el-sysroot",
         "Tarball": "debian_bullseye_mips64el_sysroot.tar.xz",
         "URL": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain"
     },
     "bullseye_mipsel": {
         "Key": "20230611T210420Z-2",
-        "Sha1Sum": "1b857baabd7999ff0d6949a8973f896836ac45ac",
+        "Sha1Sum": "ece6684704ee0c3944f1903c39fa798ee9d7f57e",
         "SysrootDir": "debian_bullseye_mipsel-sysroot",
         "Tarball": "debian_bullseye_mipsel_sysroot.tar.xz",
         "URL": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain"

--- a/tools/build.go
+++ b/tools/build.go
@@ -1037,6 +1037,8 @@ func buildStageGenerateBuildScript() {
 			} else {
 				cmakeArgs = append(cmakeArgs, "-DUSE_TCMALLOC=off")
 			}
+			// for compatibility, we build only gtk3 package for now
+			cmakeArgs = append(cmakeArgs, fmt.Sprintf("-DUSE_GTK4=off"))
 		}
 		cmakeArgs = append(cmakeArgs, fmt.Sprintf("-DENABLE_FORTIFY=on"))
 	}


### PR DESCRIPTION
new sysroots supports gtk4 but we don't build against gtk4 for now.