### PR TITLE
windows: attach parent's console if current is unavailable

### DIFF
--- a/src/win32/yass.cpp
+++ b/src/win32/yass.cpp
@@ -55,7 +55,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
   // This function is primarily useful to applications that were linked with /SUBSYSTEM:WINDOWS,
   // which implies to the operating system that a console is not needed
   // before entering the program's main method.
-  if (AttachConsole(ATTACH_PARENT_PROCESS) != 0) {
+  if (GetFileType(GetStdHandle(STD_ERROR_HANDLE)) != FILE_TYPE_UNKNOWN) {
+    fprintf(stderr, "attached to current console\n");
+    fflush(stderr);
+  } else if (AttachConsole(ATTACH_PARENT_PROCESS) != 0) {
     FILE* unusedFile;
     // Swap to the new out/err streams
     freopen_s(&unusedFile, "CONOUT$", "w", stdout);
@@ -63,7 +66,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     std::cout.clear();
     std::clog.clear();
     std::cerr.clear();
-    fprintf(stderr, "attached to parent process\n");
+    fprintf(stderr, "attached to parent process' console\n");
     fflush(stderr);
   }
 


### PR DESCRIPTION
msys2/cygwin use named pipe for console redirection see https://github.com/msys2/msys2-runtime. We can use it to detect msys2/cygwin environment where we shouldn't attach parent's console.