### PR TITLE
mingw: delayload libraries

### DIFF
--- a/.github/workflows/releases-mingw-new.yml
+++ b/.github/workflows/releases-mingw-new.yml
@@ -47,7 +47,7 @@ jobs:
           - arch: i686
             variant: msvcrt
           - arch: x86_64
-            variant: msvcrt
+            variant: ucrt
           - arch: aarch64
             variant: ucrt
     env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3840,6 +3840,169 @@ if (ENABLE_CLANG_TIDY)
 endif()
 
 # *****************************************************************************************
+#           delayload code
+# *****************************************************************************************
+if (WIN32)
+  # This is a superset of all the delayloads needed for chrome.exe, chrome.dll,
+  # and chrome_elf.dll. The linker will automatically ignore anything which is not
+  # linked to the binary at all (it is harmless to have an unmatched /delayload).
+  #
+  # We delayload most libraries as the dlls are simply not required at startup (or
+  # at all, depending on the process type). In unsandboxed process they will load
+  # when first needed.
+  #
+  # Some dlls open handles when they are loaded, and we may not want them to be
+  # loaded in renderers or other sandboxed processes. Conversely, some dlls must
+  # be loaded before sandbox lockdown.
+  #
+  # Some dlls themselves load others - in particular, to avoid unconditionally
+  # loading user32.dll - we require that the following dlls are all delayloaded:
+  # user32, gdi32, comctl32, comdlg32, cryptui, d3d9, dwmapi, imm32, msi, ole32,
+  # oleacc, rstrtmgr, shell32, shlwapi, and uxtheme.
+  #
+  # Advapi32.dll is unconditionally loaded at process startup on Windows 10, but
+  # on Windows 11 it is not, which makes it worthwhile to delay load it.
+  # Additionally, advapi32.dll exports several functions that are forwarded to
+  # other DLLs such as cryptbase.dll. If calls to those functions are present but
+  # there are some processes where the functions are never called then delay
+  # loading of advapi32.dll avoids pulling in those DLLs (such as cryptbase.dll)
+  # unnecessarily, even if advapi32.dll itself is loaded.
+  if (MSVC)
+    set(DELAY_LDFLAGS
+      "/DELAYLOAD:api-ms-win-core-synch-l1-2-0.dll"
+      "/DELAYLOAD:api-ms-win-core-winrt-error-l1-1-0.dll"
+      "/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll"
+      "/DELAYLOAD:api-ms-win-core-winrt-string-l1-1-0.dll"
+      "/DELAYLOAD:advapi32.dll"
+      "/DELAYLOAD:comctl32.dll"
+      "/DELAYLOAD:comdlg32.dll"
+      "/DELAYLOAD:credui.dll"
+      "/DELAYLOAD:cryptui.dll"
+      "/DELAYLOAD:d3d11.dll"
+      "/DELAYLOAD:d3d12.dll"
+      "/DELAYLOAD:d3d9.dll"
+      "/DELAYLOAD:dwmapi.dll"
+      "/DELAYLOAD:dxgi.dll"
+      "/DELAYLOAD:dxva2.dll"
+      "/DELAYLOAD:esent.dll"
+      "/DELAYLOAD:fontsub.dll"
+      "/DELAYLOAD:gdi32.dll"
+      "/DELAYLOAD:hid.dll"
+      "/DELAYLOAD:imagehlp.dll"
+      "/DELAYLOAD:imm32.dll"
+      "/DELAYLOAD:msi.dll"
+      "/DELAYLOAD:netapi32.dll"
+      "/DELAYLOAD:ncrypt.dll"
+      "/DELAYLOAD:ole32.dll"
+      "/DELAYLOAD:oleacc.dll"
+      "/DELAYLOAD:pdh.dll"
+      "/DELAYLOAD:propsys.dll"
+      "/DELAYLOAD:psapi.dll"
+      "/DELAYLOAD:rpcrt4.dll"
+      "/DELAYLOAD:rstrtmgr.dll"
+      "/DELAYLOAD:setupapi.dll"
+      "/DELAYLOAD:shell32.dll"
+      "/DELAYLOAD:shlwapi.dll"
+      "/DELAYLOAD:uiautomationcore.dll"
+      "/DELAYLOAD:urlmon.dll"
+      "/DELAYLOAD:user32.dll"
+      "/DELAYLOAD:usp10.dll"
+      "/DELAYLOAD:uxtheme.dll"
+      "/DELAYLOAD:wer.dll"
+      "/DELAYLOAD:wevtapi.dll"
+      "/DELAYLOAD:wininet.dll"
+      "/DELAYLOAD:winusb.dll"
+      "/DELAYLOAD:wsock32.dll"
+      "/DELAYLOAD:wtsapi32.dll"
+
+      "/DELAYLOAD:crypt32.dll"
+      "/DELAYLOAD:dbghelp.dll"
+      "/DELAYLOAD:dhcpcsvc.dll"
+      "/DELAYLOAD:dwrite.dll"
+      "/DELAYLOAD:iphlpapi.dll"
+      "/DELAYLOAD:oleaut32.dll"
+      "/DELAYLOAD:secur32.dll"
+      "/DELAYLOAD:userenv.dll"
+      "/DELAYLOAD:winhttp.dll"
+      "/DELAYLOAD:winmm.dll"
+      "/DELAYLOAD:winspool.drv"
+      "/DELAYLOAD:wintrust.dll"
+      "/DELAYLOAD:ws2_32.dll"
+      )
+    add_link_options(${DELAY_LDFLAGS})
+  endif()
+  if (MINGW AND USE_LLD)
+    set(DELAY_LDFLAGS
+      "-Wl,--delayload=api-ms-win-core-synch-l1-2-0.dll"
+      "-Wl,--delayload=api-ms-win-core-winrt-error-l1-1-0.dll"
+      "-Wl,--delayload=api-ms-win-core-winrt-l1-1-0.dll"
+      "-Wl,--delayload=api-ms-win-core-winrt-string-l1-1-0.dll"
+      "-Wl,--delayload=advapi32.dll"
+      "-Wl,--delayload=comctl32.dll"
+      "-Wl,--delayload=comdlg32.dll"
+      "-Wl,--delayload=credui.dll"
+      "-Wl,--delayload=cryptui.dll"
+      "-Wl,--delayload=d3d11.dll"
+      "-Wl,--delayload=d3d12.dll"
+      "-Wl,--delayload=d3d9.dll"
+      "-Wl,--delayload=dwmapi.dll"
+      "-Wl,--delayload=dxgi.dll"
+      "-Wl,--delayload=dxva2.dll"
+      "-Wl,--delayload=esent.dll"
+      "-Wl,--delayload=fontsub.dll"
+      "-Wl,--delayload=gdi32.dll"
+      "-Wl,--delayload=hid.dll"
+      "-Wl,--delayload=imagehlp.dll"
+      "-Wl,--delayload=imm32.dll"
+      "-Wl,--delayload=msi.dll"
+      "-Wl,--delayload=netapi32.dll"
+      "-Wl,--delayload=ncrypt.dll"
+      "-Wl,--delayload=ole32.dll"
+      "-Wl,--delayload=oleacc.dll"
+      "-Wl,--delayload=pdh.dll"
+      "-Wl,--delayload=propsys.dll"
+      "-Wl,--delayload=psapi.dll"
+      "-Wl,--delayload=rpcrt4.dll"
+      "-Wl,--delayload=rstrtmgr.dll"
+      "-Wl,--delayload=setupapi.dll"
+      "-Wl,--delayload=shell32.dll"
+      "-Wl,--delayload=shlwapi.dll"
+      "-Wl,--delayload=uiautomationcore.dll"
+      "-Wl,--delayload=urlmon.dll"
+      "-Wl,--delayload=user32.dll"
+      "-Wl,--delayload=usp10.dll"
+      "-Wl,--delayload=uxtheme.dll"
+      "-Wl,--delayload=wer.dll"
+      "-Wl,--delayload=wevtapi.dll"
+      "-Wl,--delayload=wininet.dll"
+      "-Wl,--delayload=winusb.dll"
+      "-Wl,--delayload=wsock32.dll"
+      "-Wl,--delayload=wtsapi32.dll"
+
+      "-Wl,--delayload=crypt32.dll"
+      "-Wl,--delayload=dbghelp.dll"
+      "-Wl,--delayload=dhcpcsvc.dll"
+      "-Wl,--delayload=dwrite.dll"
+      "-Wl,--delayload=iphlpapi.dll"
+      "-Wl,--delayload=oleaut32.dll"
+      "-Wl,--delayload=secur32.dll"
+      "-Wl,--delayload=userenv.dll"
+      "-Wl,--delayload=winhttp.dll"
+      "-Wl,--delayload=winmm.dll"
+      "-Wl,--delayload=winspool.drv"
+      "-Wl,--delayload=wintrust.dll"
+      "-Wl,--delayload=ws2_32.dll"
+      )
+    add_link_options(${DELAY_LDFLAGS})
+  endif()
+
+  # https://docs.microsoft.com/en-us/cpp/build/reference/understanding-the-helper-function?view=msvc-170
+  # see chrome/app/delay_load_failure_hook_win.cc
+  add_library(delayload_hook STATIC src/delay_load_failure_hook_win.cc)
+  link_libraries(delayload_hook)
+endif()
+
+# *****************************************************************************************
 #           Source code
 # *****************************************************************************************
 
@@ -4434,87 +4597,6 @@ if (GUI)
       ${GUI_LIBRARIES}
       yass_core
     )
-
-    if (GUI_FLAVOUR STREQUAL "windows" AND MSVC)
-      # Most of the dlls are simply not required at startup (or at all, depending
-      # on how the browser is used). The following dlls are interconnected and need to
-      # be delayloaded together to ensure user32 does not load too early or at all,
-      # depending on the process type: user32, gdi32, comctl32, comdlg32, cryptui,
-      # d3d9, dwmapi, imm32, msi, ole32, oleacc, rstrtmgr, shell32, shlwapi, and
-      # uxtheme.
-      set (DELAY_LDFLAGS
-        "/DELAYLOAD:api-ms-win-core-winrt-error-l1-1-0.dll"
-        "/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll"
-        "/DELAYLOAD:api-ms-win-core-winrt-string-l1-1-0.dll"
-        "/DELAYLOAD:comctl32.dll"
-        "/DELAYLOAD:comdlg32.dll"
-        "/DELAYLOAD:credui.dll"
-        "/DELAYLOAD:cryptui.dll"
-        "/DELAYLOAD:d3d11.dll"
-        "/DELAYLOAD:d3d9.dll"
-        "/DELAYLOAD:dwmapi.dll"
-        "/DELAYLOAD:dxgi.dll"
-        "/DELAYLOAD:dxva2.dll"
-        "/DELAYLOAD:esent.dll"
-        "/DELAYLOAD:gdi32.dll"
-        "/DELAYLOAD:hid.dll"
-        "/DELAYLOAD:imagehlp.dll"
-        "/DELAYLOAD:imm32.dll"
-        "/DELAYLOAD:msi.dll"
-        "/DELAYLOAD:netapi32.dll"
-        "/DELAYLOAD:ncrypt.dll"
-        "/DELAYLOAD:ole32.dll"
-        "/DELAYLOAD:oleacc.dll"
-        "/DELAYLOAD:propsys.dll"
-        "/DELAYLOAD:psapi.dll"
-        "/DELAYLOAD:rpcrt4.dll"
-        "/DELAYLOAD:rstrtmgr.dll"
-        "/DELAYLOAD:setupapi.dll"
-        "/DELAYLOAD:shell32.dll"
-        "/DELAYLOAD:shlwapi.dll"
-        "/DELAYLOAD:urlmon.dll"
-        "/DELAYLOAD:user32.dll"
-        "/DELAYLOAD:usp10.dll"
-        "/DELAYLOAD:uxtheme.dll"
-        "/DELAYLOAD:wer.dll"
-        "/DELAYLOAD:wevtapi.dll"
-        "/DELAYLOAD:wininet.dll"
-        "/DELAYLOAD:winusb.dll"
-        "/DELAYLOAD:wsock32.dll"
-        "/DELAYLOAD:wtsapi32.dll"
-
-        "/DELAYLOAD:advapi32.dll"
-        "/DELAYLOAD:crypt32.dll"
-        "/DELAYLOAD:dbghelp.dll"
-        "/DELAYLOAD:dhcpcsvc.dll"
-        "/DELAYLOAD:dwrite.dll"
-        "/DELAYLOAD:iphlpapi.dll"
-        "/DELAYLOAD:oleaut32.dll"
-        "/DELAYLOAD:secur32.dll"
-        "/DELAYLOAD:uiautomationcore.dll"
-        "/DELAYLOAD:userenv.dll"
-        "/DELAYLOAD:winhttp.dll"
-        "/DELAYLOAD:winmm.dll"
-        "/DELAYLOAD:winspool.drv"
-        "/DELAYLOAD:wintrust.dll"
-        "/DELAYLOAD:ws2_32.dll"
-        )
-      # TODO implement own delay load helper
-      # https://docs.microsoft.com/en-us/cpp/build/reference/understanding-the-helper-function?view=msvc-170
-      # __pfnDliFailureHook2: Delay load failure hook that generates a crash report. By default a failure
-      # to delay load will trigger an exception handled by the delay load runtime and
-      # this won't generate a crash report.
-      # https://docs.microsoft.com/en-us/cpp/build/reference/failure-hooks?view=vs-2019
-      # __pfnDliNotifyHook2: verify if loaded libraries are allowed
-      # FIXME it seems delay loader's delayimp library isn't be found correctly
-      # when it comes with static CRT build.
-      string(REPLACE ";" " " DELAY_LDFLAGS "${DELAY_LDFLAGS}")
-      set_target_properties(${APP_NAME} PROPERTIES
-        LINK_FLAGS "${DELAY_LDFLAGS}")
-
-      # enforce default delayload implementation
-      target_link_libraries(${APP_NAME} PUBLIC delayimp)
-    endif()
 
     if (GUI_FLAVOUR STREQUAL "windows" AND MSVC)
         set_target_properties(${APP_NAME} PROPERTIES

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SRC_DIR := src
 SRC_FILES := $(wildcard $(SRC_DIR)/*.mm)
+SRC_FILES := $(wildcard $(SRC_DIR)/*.cc)
 SRC_FILES := $(wildcard $(SRC_DIR)/*.cpp)
 SRC_FILES += $(wildcard $(SRC_DIR)/*.hpp)
 SRC_FILES += $(wildcard $(SRC_DIR)/android/*.cpp)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [Protecting Chrome Traffic with Hybrid Kyber KEM](https://blog.chromium.org/
 ### Prebuilt binaries
 - Android [download apk](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-android-release-arm64-1.10.4.apk) or [download 32-bit apk](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-android-release-arm-1.10.4.apk)
 - iOS [join via TestFlight](https://testflight.apple.com/join/6AkiEq09)
-- Windows [download installer](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-mingw-win7-release-x86_64-1.10.4-system-installer.exe) or [download 32-bit installer](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-mingw-winxp-release-i686-1.10.4-system-installer.exe) [(require vc 2010 runtime)][vs2010_x86] or [download woa arm64 installer](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-mingw-release-aarch64-1.10.4-system-installer.exe)
+- Windows [download installer](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-mingw-win7-release-x86_64-1.10.4-system-installer.exe) [(require KB2999226 below windows 10)][KB2999226] or [download 32-bit installer](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-mingw-winxp-release-i686-1.10.4-system-installer.exe) [(require vc 2010 runtime)][vs2010_x86] or [download woa arm64 installer](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-mingw-release-aarch64-1.10.4-system-installer.exe)
 - macOS [download intel dmg](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-macos-release-x64-1.10.4.dmg) or [download apple silicon dmg](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-macos-release-arm64-1.10.4.dmg)
 > via homebrew: `brew install --cask yass`
 - Linux [download rpm](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass.el7.x86_64.1.10.4.rpm) or [download deb](https://github.com/Chilledheart/yass/releases/download/1.10.4/yass-ubuntu-16.04-xenial_amd64.1.10.4.deb)
@@ -107,4 +107,5 @@ See more at manpage _yass_server(1)_
 See [Server Usage](https://github.com/Chilledheart/yass/wiki/Usage:-server-setup) for more.
 
 [license-link]: LICENSE
+[KB2999226]: https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c
 [vs2010_x86]: https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe

--- a/src/delay_load_failure_hook_win.cc
+++ b/src/delay_load_failure_hook_win.cc
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2024 Chilledheart  */
+
+// windows.h needs to be included before delayimp.h.
+#include <windows.h>
+
+#define __pfnDliFailureHook2 __pfnDliFailureHook2Hidden
+#include <delayimp.h>
+#undef __pfnDliFailureHook2
+#include <stdlib.h>
+
+namespace yass {
+
+extern void DisableDelayLoadFailureHooksForMainExecutable();
+
+extern FARPROC WINAPI HandleDelayLoadFailureCommon(unsigned reason, DelayLoadInfo* dll_info);
+
+FARPROC WINAPI HandleDelayLoadFailureCommon(unsigned reason,
+                                            DelayLoadInfo* dll_info) {
+  // ERROR_COMMITMENT_LIMIT means that there is no memory. Convert this into a
+  // more suitable crash rather than just CHECKing in this function.
+  if (dll_info->dwLastError == ERROR_COMMITMENT_LIMIT) {
+    _exit(255);
+  }
+
+  // DEBUG_ALIAS_FOR_CSTR(dll_name, dll_info->szDll, 256);
+  // SCOPED_CRASH_KEY_STRING256("DelayLoad", "ModuleName", dll_name);
+
+  // Deterministically crash here. Returning 0 from the hook would likely result
+  // in the process crashing anyway, but in a form that might trigger undefined
+  // behavior or be hard to diagnose. See https://crbug.com/1320845.
+  abort();
+
+  return 0;
+}
+
+namespace {
+
+bool g_hooks_enabled = true;
+
+// Delay load failure hook that generates a crash report. By default a failure
+// to delay load will trigger an exception handled by the delay load runtime and
+// this won't generate a crash report.
+FARPROC WINAPI DelayLoadFailureHookEXE(unsigned reason,
+                                       DelayLoadInfo* dll_info) {
+  if (!g_hooks_enabled)
+    return 0;
+
+  return HandleDelayLoadFailureCommon(reason, dll_info);
+}
+
+}  // namespace
+
+void DisableDelayLoadFailureHooksForMainExecutable() {
+  g_hooks_enabled = false;
+}
+
+}  // namespace yass
+
+// Set the delay load failure hook to the function above.
+//
+// The |__pfnDliFailureHook2| failure notification hook gets called
+// automatically by the delay load runtime in case of failure, see
+// https://docs.microsoft.com/en-us/cpp/build/reference/failure-hooks?view=vs-2019
+// for more information about this.
+extern "C" const PfnDliHook __pfnDliFailureHook2 =
+    yass::DelayLoadFailureHookEXE;


### PR DESCRIPTION
after this patch, it is no longer disabling tcmalloc on arm64 machine.

however, this trick doesn't apply to msvcrt runtime. so we switch to ucrt for x64 binaries.