### PR TITLE
posix: block SIGPIPE in all threads

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -57,6 +57,21 @@ static asio::ip::tcp::resolver::results_type ResolveAddress(const std::string& d
 }
 
 int main(int argc, const char* argv[]) {
+#ifndef _WIN32
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    return -1;
+  }
+#endif
   SetExecutablePath(argv[0]);
   std::string exec_path;
   if (!GetExecutablePath(&exec_path)) {
@@ -205,10 +220,6 @@ int main(int argc, const char* argv[]) {
     signals.clear();
   };
   signals.async_wait(cb);
-
-#if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_OHOS)
-  CHECK_NE(SIG_ERR, signal(SIGPIPE, SIG_IGN));
-#endif
 
   io_context.run();
 

--- a/src/gtk/yass.cpp
+++ b/src/gtk/yass.cpp
@@ -33,6 +33,21 @@ static const char* kAppId = "it.gui.yass";
 static const char* kAppName = YASS_APP_PRODUCT_NAME;
 
 int main(int argc, const char** argv) {
+#ifndef _WIN32
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    return -1;
+  }
+#endif
   SetExecutablePath(argv[0]);
   std::string exec_path;
   if (!GetExecutablePath(&exec_path)) {

--- a/src/gtk4/yass.cpp
+++ b/src/gtk4/yass.cpp
@@ -98,6 +98,21 @@ YASSGtkApp* yass_app_new(void) {
 }  // extern "C"
 
 int main(int argc, const char** argv) {
+#ifndef _WIN32
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    return -1;
+  }
+#endif
   SetExecutablePath(argv[0]);
   std::string exec_path;
   if (!GetExecutablePath(&exec_path)) {

--- a/src/harmony/yass.cpp
+++ b/src/harmony/yass.cpp
@@ -9,6 +9,8 @@
 #include <js_native_api_types.h>
 #include <napi/native_api.h>
 
+#include <pthread.h>
+#include <signal.h>
 #include <unistd.h>
 #include <memory>
 #include <thread>
@@ -1153,6 +1155,20 @@ static napi_module yassModule = {
 };
 
 extern "C" __attribute__((constructor)) void RegisterEntryModule(void) {
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    return -1;
+  }
+
   napi_module_register(&yassModule);
 }
 

--- a/src/ios/extensions/YassPacketTunnelProvider.mm
+++ b/src/ios/extensions/YassPacketTunnelProvider.mm
@@ -3,6 +3,8 @@
 
 #import "YassPacketTunnelProvider.h"
 
+#include <pthread.h>
+#include <signal.h>
 #include <atomic>
 #include <thread>
 
@@ -34,6 +36,22 @@ static constexpr const uint32_t kYieldConcurrencyOfConnections = 12u;
 
 - (void)startTunnelWithOptions:(NSDictionary*)options completionHandler:(void (^)(NSError*))completionHandler {
   stopped_ = false;
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    completionHandler([NSError errorWithDomain:@"it.gui.ios.yass"
+                                          code:200
+                                      userInfo:@{@"Error reason" : @(strerror(errno))}]);
+    return;
+  }
   SetExecutablePath("UNKNOWN.ext");
 
   NETunnelProviderProtocol* protocolConfiguration = (NETunnelProviderProtocol*)self.protocolConfiguration;

--- a/src/ios/main.mm
+++ b/src/ios/main.mm
@@ -5,6 +5,8 @@
 
 #include <locale.h>
 #include <mach-o/dyld.h>
+#include <pthread.h>
+#include <signal.h>
 #include <stdexcept>
 #include <string>
 
@@ -26,6 +28,19 @@
 const ProgramType pType = YASS_CLIENT_SLAVE;
 
 int main(int argc, const char** argv) {
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    return -1;
+  }
   SetExecutablePath(argv[0]);
   std::string exec_path;
   if (!GetExecutablePath(&exec_path)) {

--- a/src/qt6/yass.cpp
+++ b/src/qt6/yass.cpp
@@ -27,6 +27,21 @@
 #include "version.h"
 
 int main(int argc, const char** argv) {
+#ifndef _WIN32
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    return -1;
+  }
+#endif
   SetExecutablePath(argv[0]);
   std::string exec_path;
   if (!GetExecutablePath(&exec_path)) {
@@ -58,30 +73,6 @@ int main(int argc, const char** argv) {
   CRYPTO_library_init();
 
   YASSApp program(argc, const_cast<char**>(argv));
-
-#ifndef _WIN32
-  // setup signal handler
-  signal(SIGPIPE, SIG_IGN);
-
-  struct sigaction sig_handler;
-
-  sig_handler.sa_handler = [](int signal_num) { App()->quit(); };
-  sigemptyset(&sig_handler.sa_mask);
-  sig_handler.sa_flags = 0;
-
-  sigaction(SIGINT, &sig_handler, nullptr);
-
-  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
-     a closed pipe. */
-  sigset_t sigpipe_mask;
-  sigemptyset(&sigpipe_mask);
-  sigaddset(&sigpipe_mask, SIGPIPE);
-  sigset_t saved_mask;
-  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
-    PLOG(WARNING) << "pthread_sigmask failed";
-    return -1;
-  }
-#endif
 
   // call program init
   if (!program.Init()) {

--- a/src/ss_benchmark.cpp
+++ b/src/ss_benchmark.cpp
@@ -583,6 +583,21 @@ int xc_main() {
 #else
 int main(int argc, char** argv) {
 #endif
+#ifndef _WIN32
+  // setup signal handler
+  signal(SIGPIPE, SIG_IGN);
+
+  /* Block SIGPIPE in all threads, this can happen if a thread calls write on
+     a closed pipe. */
+  sigset_t sigpipe_mask;
+  sigemptyset(&sigpipe_mask);
+  sigaddset(&sigpipe_mask, SIGPIPE);
+  sigset_t saved_mask;
+  if (pthread_sigmask(SIG_BLOCK, &sigpipe_mask, &saved_mask) == -1) {
+    perror("pthread_sigmask failed");
+    return -1;
+  }
+#endif
   SetExecutablePath(argv[0]);
   std::string exec_path;
   if (!GetExecutablePath(&exec_path)) {
@@ -630,10 +645,6 @@ int main(int argc, char** argv) {
 #endif
 
   CRYPTO_library_init();
-
-#if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_OHOS)
-  CHECK_NE(SIG_ERR, signal(SIGPIPE, SIG_IGN));
-#endif
 
   if (absl::GetFlag(FLAGS_ipv6_mode)) {
     CHECK(Net_ipv6works()) << "IPv6 stack is required but not available";


### PR DESCRIPTION
This can happen when trying to write to a closed socket.

pthread_sigmask should be called before thread creation.