### PR TITLE
net: avoid duplicated calls with non blocking mode

### DIFF
--- a/src/net/content_server.hpp
+++ b/src/net/content_server.hpp
@@ -254,7 +254,6 @@ class ContentServer {
     ListenCtx& ctx = listen_ctxs_[listen_ctx_num];
 
     int connection_id = next_connection_id_++;
-    socket.native_non_blocking(true, ec);
     socket.non_blocking(true, ec);
     SetTCPCongestion(socket.native_handle(), ec);
     SetTCPKeepAlive(socket.native_handle(), ec);

--- a/src/net/doh_request.cpp
+++ b/src/net/doh_request.cpp
@@ -81,7 +81,6 @@ void DoHRequest::DoRequest(dns_message::DNStype dns_type, const std::string& hos
     OnDoneRequest(ec, nullptr);
     return;
   }
-  socket_.native_non_blocking(true, ec);
   socket_.non_blocking(true, ec);
   scoped_refptr<DoHRequest> self(this);
   socket_.async_connect(endpoint_, [this, self](asio::error_code ec) {

--- a/src/net/dot_request.cpp
+++ b/src/net/dot_request.cpp
@@ -73,7 +73,6 @@ void DoTRequest::DoRequest(dns_message::DNStype dns_type, const std::string& hos
     OnDoneRequest(ec, nullptr);
     return;
   }
-  socket_.native_non_blocking(true, ec);
   socket_.non_blocking(true, ec);
   scoped_refptr<DoTRequest> self(this);
   socket_.async_connect(endpoint_, [this, self](asio::error_code ec) {

--- a/src/net/ssl_server_socket.cpp
+++ b/src/net/ssl_server_socket.cpp
@@ -41,7 +41,6 @@ SSLServerSocket::~SSLServerSocket() {
 int SSLServerSocket::Handshake(CompletionOnceCallback callback) {
   CHECK(!disconnected_);
 
-  DCHECK(stream_socket_->native_non_blocking());
   DCHECK(stream_socket_->non_blocking());
 
   SSL_set_fd(ssl_.get(), stream_socket_->native_handle());

--- a/src/net/ssl_socket.cpp
+++ b/src/net/ssl_socket.cpp
@@ -149,7 +149,6 @@ int SSLSocket::Connect(CompletionOnceCallback callback) {
   // https://crbug.com/499289.
   CHECK(!disconnected_);
 
-  DCHECK(stream_socket_->native_non_blocking());
   DCHECK(stream_socket_->non_blocking());
 
   SSL_set_fd(ssl_.get(), stream_socket_->native_handle());

--- a/src/net/stream.hpp
+++ b/src/net/stream.hpp
@@ -369,7 +369,6 @@ class stream : public RefCountedThreadSafe<stream> {
     setProtectFd(socket_.native_handle());
 #endif
     SetTCPFastOpenConnect(socket_.native_handle(), ec);
-    socket_.native_non_blocking(true, ec);
     socket_.non_blocking(true, ec);
     scoped_refptr<stream> self(this);
     if (auto connect_timeout = absl::GetFlag(FLAGS_connect_timeout)) {


### PR DESCRIPTION
asio calls set_user_non_blocking for non_blocking and set_internal_non_blocking for native_non_blocking.

actually, those calls are identicial in implementation except that non_blocking call takes care of asio synchronous calls while native_non_blocking call doesn't.