### PR TITLE
android: support 16k page size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -993,6 +993,11 @@ if (NOT MSVC)
   if (ANDROID OR OHOS)
     add_definitions(-D__GNU_SOURCE=1)
   endif()
+  # support for 16k page size
+  # https://developer.android.com/guide/practices/page-sizes#compile-r26-lower
+  if (ANDROID)
+    add_link_options(-Wl,-z,max-page-size=16384)
+  endif()
 
   ## optimization flags
   ## TODO Changed in version 3.19: Multiple configurations can be specified for cfgs


### PR DESCRIPTION
https://developer.android.com/guide/practices/page-sizes#compile-r26-lower

optional TODO upgradet AGP to 8.5.1

    If you can't upgrade AGP to version 8.5.1 or higher, then the
    alternative is to switch to use compressed shared libraries. Update your
    Gradle configuration to have Gradle compress your shared libraries when
    packaging your app to avoid app installation issues with unaligned
    shared libraries.

optional TODO upgrade to NDK 27 or later

    Even if your app dynamically links to the C++ standard library
    (libc++_shared.so) from NDKs r26 and lower, some of which are not
    16 KB aligned, you should still update the alignment of all other libraries
    here, and you should update your code to avoid depending on PAGE_SIZE.

See #1108