### PR TITLE
tls: Add a flag to use ML-KEM instead of Kyber

### DIFF
--- a/doc/yass_cli.md
+++ b/doc/yass_cli.md
@@ -104,7 +104,10 @@ See <https://github.com/Chilledheart/yass/wiki/Usage>.
   Enable 0RTTI Early Data.
 
 * `--enable_post_quantum_kyber`:
-  Enable post-quantum secure TLS key encapsulation mechanism X25519Kyber768, based on a NIST standard (ML-KEM).
+  Enables post-quantum key-agreements in TLS 1.3 connections. The _use_ml_kem_ flag controls whether ML-KEM or Kyber is used.
+
+* `--use_ml_kem`:
+  Use ML-KEM in TLS 1.3. Causes TLS 1.3 connections to use the ML-KEM standard instead of the Kyber draft standard for post-quantum key-agreement. The _enable_post_quantum_kyber_ flag must be enabled for this to have an effect.
 
 * `--congestion_algorithm` _algo_:
   Specify _algo_ as TCP congestion control algorithm for underlying TCP connections (Linux Only)

--- a/doc/yass_server.md
+++ b/doc/yass_server.md
@@ -111,6 +111,12 @@ See <https://github.com/Chilledheart/yass/wiki/Usage>.
 * `--hide_via`:
   If true, the Via header will not be added.
 
+* `--enable_post_quantum_kyber`:
+  Enables post-quantum key-agreements in TLS 1.3 connections. The _use_ml_kem_ flag controls whether ML-KEM or Kyber is used.
+
+* `--use_ml_kem`:
+  Use ML-KEM in TLS 1.3. Causes TLS 1.3 connections to use the ML-KEM standard instead of the Kyber draft standard for post-quantum key-agreement. The _enable_post_quantum_kyber_ flag must be enabled for this to have an effect.
+
 * `--congestion_algorithm` _algo_:
   Specify _algo_ as TCP congestion control algorithm for underlying TCP connections (Linux Only)
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -495,6 +495,8 @@ void SetServerUsageMessage(std::string_view exec_path) {
   --certificate_chain_file <file> Use custom certificate chain file to verify server's certificate
   --private_key_file <file> Use custom private key file to secure connection between server and client
   --private_key_password <password> Use custom private key password to decrypt server's encrypted private key
+  --enable_post_quantum_kyber Enables post-quantum key-agreements in TLS 1.3 connections. The use_ml_kem flag controls whether ML-KEM or Kyber is used.
+  --use_ml_kem Use ML-KEM in TLS 1.3. Causes TLS 1.3 connections to use the ML-KEM standard instead of the Kyber draft standard for post-quantum key-agreement. The enable_post_quantum_kyber flag must be enabled for this to have an effect.
 )"));
 }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -472,7 +472,8 @@ void SetClientUsageMessage(std::string_view exec_path) {
   --certificate_chain_file <file> Use custom certificate chain file to verify server's certificate
   -k, --insecure_mode Skip the verification step and proceed without checking
   --tls13_early_data Enable 0RTTI Early Data
-  --enable_post_quantum_kyber Enable post-quantum secure TLS key encapsulation mechanism X25519Kyber768, based on a NIST standard (ML-KEM)
+  --enable_post_quantum_kyber Enables post-quantum key-agreements in TLS 1.3 connections. The use_ml_kem flag controls whether ML-KEM or Kyber is used.
+  --use_ml_kem Use ML-KEM in TLS 1.3. Causes TLS 1.3 connections to use the ML-KEM standard instead of the Kyber draft standard for post-quantum key-agreement. The enable_post_quantum_kyber flag must be enabled for this to have an effect.
 )"));
 }
 
@@ -494,7 +495,6 @@ void SetServerUsageMessage(std::string_view exec_path) {
   --certificate_chain_file <file> Use custom certificate chain file to verify server's certificate
   --private_key_file <file> Use custom private key file to secure connection between server and client
   --private_key_password <password> Use custom private key password to decrypt server's encrypted private key
-  --tls13_early_data Enable 0RTTI Early Data
 )"));
 }
 

--- a/src/config/config_tls.cpp
+++ b/src/config/config_tls.cpp
@@ -36,8 +36,7 @@ ABSL_FLAG(bool,
           enable_post_quantum_kyber,
           false,
           "Enables post-quantum key-agreements in TLS 1.3 connections. "
-          "The use_ml_kem flag controls whether ML-KEM or Kyber is used. "
-          "(Client Only)");
+          "The use_ml_kem flag controls whether ML-KEM or Kyber is used.");
 ABSL_FLAG(bool,
           use_ml_kem,
           false,
@@ -45,8 +44,7 @@ ABSL_FLAG(bool,
           "Causes TLS 1.3 connections to use the ML-KEM standard instead of the Kyber "
           "draft standard for post-quantum key-agreement. "
           "The enable_post_quantum_kyber flag must be enabled "
-          "for this to have an effect. "
-          "(Client Only)");
+          "for this to have an effect.");
 
 namespace config {
 bool ReadTLSConfigFile() {

--- a/src/config/config_tls.cpp
+++ b/src/config/config_tls.cpp
@@ -31,11 +31,22 @@ ABSL_FLAG(std::string,
 ABSL_FLAG(std::string, capath, "", "Tells where to use the specified certificate directory to verify the peer");
 
 ABSL_FLAG(bool, tls13_early_data, true, "Enable 0RTTI Early Data (risk at production)");
+
 ABSL_FLAG(bool,
           enable_post_quantum_kyber,
           false,
-          "Enable post-quantum secure TLS key encapsulation mechanism X25519Kyber768, based on a NIST standard "
-          "(ML-KEM) (Client only)");
+          "Enables post-quantum key-agreements in TLS 1.3 connections. "
+          "The use_ml_kem flag controls whether ML-KEM or Kyber is used. "
+          "(Client Only)");
+ABSL_FLAG(bool,
+          use_ml_kem,
+          false,
+          "Use ML-KEM in TLS 1.3. "
+          "Causes TLS 1.3 connections to use the ML-KEM standard instead of the Kyber "
+          "draft standard for post-quantum key-agreement. "
+          "The enable_post_quantum_kyber flag must be enabled "
+          "for this to have an effect. "
+          "(Client Only)");
 
 namespace config {
 bool ReadTLSConfigFile() {

--- a/src/config/config_tls.hpp
+++ b/src/config/config_tls.hpp
@@ -17,6 +17,7 @@ ABSL_DECLARE_FLAG(std::string, cacert);
 ABSL_DECLARE_FLAG(std::string, capath);
 ABSL_DECLARE_FLAG(bool, tls13_early_data);
 ABSL_DECLARE_FLAG(bool, enable_post_quantum_kyber);
+ABSL_DECLARE_FLAG(bool, use_ml_kem);
 
 namespace config {
 bool ReadTLSConfigFile();

--- a/src/crypto/crypter_export.hpp
+++ b/src/crypto/crypter_export.hpp
@@ -42,6 +42,9 @@
 #define CIPHER_METHOD_MAP_HTTP(XX) XX(0x110U, HTTPS, "https")
 
 #ifdef HAVE_QUICHE
+#define CIPHER_METHOD_MAP_HTTPS(XX) \
+  CIPHER_METHOD_MAP_HTTP(XX)        \
+  XX(0x121U, HTTP2, "http2")
 #define CIPHER_METHOD_MAP_HTTP2(XX)              \
   XX(0x120U, HTTP2_PLAINTEXT, "http2-plaintext") \
   XX(0x121U, HTTP2, "http2")
@@ -53,6 +56,7 @@
   XX(0x124U, HTTP2_INPLACE_4, "http2-4-protocol") \
   XX(0x125U, HTTP2_INPLACE_5, "http2-5-protocol")
 #else
+#define CIPHER_METHOD_MAP_HTTPS(XX) CIPHER_METHOD_MAP_HTTP(XX)
 #define CIPHER_METHOD_MAP_HTTP2(XX)
 #endif
 

--- a/src/net/ssl_server_socket.cpp
+++ b/src/net/ssl_server_socket.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright (c) 2023 Chilledheart  */
+/* Copyright (c) 2023-2024 Chilledheart  */
 
 #include "net/ssl_server_socket.hpp"
 
+#include "config/config_tls.hpp"
 #include "net/openssl_util.hpp"
 #include "third_party/boringssl/src/include/openssl/err.h"
 
@@ -28,7 +29,13 @@ SSLServerSocket::SSLServerSocket(asio::io_context* io_context, asio::ip::tcp::so
   // TODO:
   // Set certificate and private key.
   // SSL_set_signing_algorithm_prefs
-  // SSL_set1_curves
+  if (TEST_post_quantumn_only_mode && absl::GetFlag(FLAGS_enable_post_quantum_kyber)) {
+    const uint16_t postquantum_group =
+        absl::GetFlag(FLAGS_use_ml_kem) ? SSL_GROUP_X25519_MLKEM768 : SSL_GROUP_X25519_KYBER768_DRAFT00;
+    const uint16_t kGroups[] = {postquantum_group};
+    int ret = SSL_set1_group_ids(ssl_.get(), kGroups, std::size(kGroups));
+    CHECK_EQ(ret, 1) << "SSL_set1_group_ids failure";
+  }
 }
 
 SSLServerSocket::~SSLServerSocket() {
@@ -481,5 +488,7 @@ int SSLServerSocket::MapLastOpenSSLError(int ssl_error) {
 
   return net_error;
 }
+
+bool SSLServerSocket::TEST_post_quantumn_only_mode = false;
 
 }  // namespace net

--- a/src/net/ssl_server_socket.cpp
+++ b/src/net/ssl_server_socket.cpp
@@ -35,6 +35,12 @@ SSLServerSocket::SSLServerSocket(asio::io_context* io_context, asio::ip::tcp::so
     const uint16_t kGroups[] = {postquantum_group};
     int ret = SSL_set1_group_ids(ssl_.get(), kGroups, std::size(kGroups));
     CHECK_EQ(ret, 1) << "SSL_set1_group_ids failure";
+  } else if (absl::GetFlag(FLAGS_enable_post_quantum_kyber)) {
+    const uint16_t postquantum_group =
+        absl::GetFlag(FLAGS_use_ml_kem) ? SSL_GROUP_X25519_MLKEM768 : SSL_GROUP_X25519_KYBER768_DRAFT00;
+    const uint16_t kGroups[] = {postquantum_group, SSL_GROUP_X25519, SSL_GROUP_SECP256R1, SSL_GROUP_SECP384R1};
+    int ret = SSL_set1_group_ids(ssl_.get(), kGroups, std::size(kGroups));
+    CHECK_EQ(ret, 1) << "SSL_set1_group_ids failure";
   }
 }
 

--- a/src/net/ssl_server_socket.hpp
+++ b/src/net/ssl_server_socket.hpp
@@ -96,6 +96,13 @@ class SSLServerSocket : public RefCountedThreadSafe<SSLServerSocket> {
 
   // True if the socket has been disconnected.
   bool disconnected_ = false;
+
+  // FIXME allow gtest_prod.h inclusion?
+ public:
+  static void TEST_set_post_quantumn_only_mode(bool enabled) { TEST_post_quantumn_only_mode = enabled; }
+
+ private:
+  static bool TEST_post_quantumn_only_mode;
 };
 
 }  // namespace net

--- a/src/net/ssl_socket.cpp
+++ b/src/net/ssl_socket.cpp
@@ -57,9 +57,11 @@ SSLSocket::SSLSocket(int ssl_socket_data_index,
   }
 
   if (absl::GetFlag(FLAGS_enable_post_quantum_kyber)) {
-    static constexpr const int kCurves[] = {NID_X25519Kyber768Draft00, NID_X25519, NID_X9_62_prime256v1, NID_secp384r1};
-    int ret = SSL_set1_curves(ssl_.get(), kCurves, std::size(kCurves));
-    CHECK_EQ(ret, 1) << "SSL_set1_curves failure";
+    const uint16_t postquantum_group =
+        absl::GetFlag(FLAGS_use_ml_kem) ? SSL_GROUP_X25519_MLKEM768 : SSL_GROUP_X25519_KYBER768_DRAFT00;
+    const uint16_t kGroups[] = {postquantum_group, SSL_GROUP_X25519, SSL_GROUP_SECP256R1, SSL_GROUP_SECP384R1};
+    int ret = SSL_set1_group_ids(ssl_.get(), kGroups, std::size(kGroups));
+    CHECK_EQ(ret, 1) << "SSL_set1_group_ids failure";
   }
 
   SSL_set_early_data_enabled(ssl_.get(), early_data_enabled_);

--- a/src/ss_test.cpp
+++ b/src/ss_test.cpp
@@ -736,6 +736,38 @@ class EndToEndTest : public ::testing::TestWithParam<cipher_method> {
   std::unique_ptr<cli::CliServer> local_server_;
   asio::ip::tcp::endpoint local_endpoint_;
 };
+
+class EndToEndTestPostQuantumnKyber : public EndToEndTest {
+ protected:
+  void SetUp() override {
+    absl::SetFlag(&FLAGS_enable_post_quantum_kyber, true);
+    absl::SetFlag(&FLAGS_use_ml_kem, false);
+    net::SSLServerSocket::TEST_set_post_quantumn_only_mode(true);
+    EndToEndTest::SetUp();
+  }
+  void TearDown() override {
+    EndToEndTest::TearDown();
+    net::SSLServerSocket::TEST_set_post_quantumn_only_mode(false);
+    absl::SetFlag(&FLAGS_enable_post_quantum_kyber, false);
+    absl::SetFlag(&FLAGS_use_ml_kem, false);
+  }
+};
+
+class EndToEndTestPostQuantumnMLKEM : public EndToEndTest {
+ protected:
+  void SetUp() override {
+    absl::SetFlag(&FLAGS_enable_post_quantum_kyber, true);
+    absl::SetFlag(&FLAGS_use_ml_kem, true);
+    net::SSLServerSocket::TEST_set_post_quantumn_only_mode(true);
+    EndToEndTest::SetUp();
+  }
+  void TearDown() override {
+    EndToEndTest::TearDown();
+    net::SSLServerSocket::TEST_set_post_quantumn_only_mode(false);
+    absl::SetFlag(&FLAGS_enable_post_quantum_kyber, false);
+    absl::SetFlag(&FLAGS_use_ml_kem, false);
+  }
+};
 }  // namespace
 
 TEST_P(EndToEndTest, 4K) {
@@ -762,6 +794,56 @@ static constexpr const cipher_method kCiphers[] = {
 INSTANTIATE_TEST_SUITE_P(Ss,
                          EndToEndTest,
                          ::testing::ValuesIn(kCiphers),
+                         [](const ::testing::TestParamInfo<cipher_method>& info) -> std::string {
+                           return std::string(to_cipher_method_name(info.param));
+                         });
+
+TEST_P(EndToEndTestPostQuantumnKyber, 4K) {
+  GenerateRandContent(4096);
+  SendRequestAndCheckResponse();
+}
+
+TEST_P(EndToEndTestPostQuantumnKyber, 256K) {
+  GenerateRandContent(256 * 1024);
+  SendRequestAndCheckResponse();
+}
+
+TEST_P(EndToEndTestPostQuantumnKyber, 1M) {
+  GenerateRandContent(1024 * 1024);
+  SendRequestAndCheckResponse();
+}
+
+static constexpr const cipher_method kCiphersHttps[] = {
+#define XX(num, name, string) CRYPTO_##name,
+    CIPHER_METHOD_MAP_HTTPS(XX)
+#undef XX
+};
+
+INSTANTIATE_TEST_SUITE_P(Ss,
+                         EndToEndTestPostQuantumnKyber,
+                         ::testing::ValuesIn(kCiphersHttps),
+                         [](const ::testing::TestParamInfo<cipher_method>& info) -> std::string {
+                           return std::string(to_cipher_method_name(info.param));
+                         });
+
+TEST_P(EndToEndTestPostQuantumnMLKEM, 4K) {
+  GenerateRandContent(4096);
+  SendRequestAndCheckResponse();
+}
+
+TEST_P(EndToEndTestPostQuantumnMLKEM, 256K) {
+  GenerateRandContent(256 * 1024);
+  SendRequestAndCheckResponse();
+}
+
+TEST_P(EndToEndTestPostQuantumnMLKEM, 1M) {
+  GenerateRandContent(1024 * 1024);
+  SendRequestAndCheckResponse();
+}
+
+INSTANTIATE_TEST_SUITE_P(Ss,
+                         EndToEndTestPostQuantumnMLKEM,
+                         ::testing::ValuesIn(kCiphersHttps),
                          [](const ::testing::TestParamInfo<cipher_method>& info) -> std::string {
                            return std::string(to_cipher_method_name(info.param));
                          });


### PR DESCRIPTION
The flag is disabled by default for now. We'll enable it by default after server early adopters have had time to deploy the new codepoint.

ML-KEM and Kyber are very similar, so the compatibility and performance risks between the two are expected to be identical. Thus, to minimize interruption to enterprise administrators, ML-KEM is still gated on the same flags as Kyber was. The new flag changes the meaning of the old flags to gate Kyber instead.

See https://chromium-review.googlesource.com/c/chromium/src/+/5823718 and https://boringssl-review.googlesource.com/c/boringssl/+/70547.

Related to #935.