### PR TITLE
android: use -O3 instead of -Os for gh releases

### DIFF
--- a/.github/workflows/releases-android-binary.yml
+++ b/.github/workflows/releases-android-binary.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           # FIXME required by next step, need to copy to current clang with ndk's libunwind.a
           ./tools/build --variant gui --arch ${{ matrix.arch }} --system android \
-            -cmake-build-type MinSizeRel -no-build -no-configure \
+            -cmake-build-type Release -no-build -no-configure \
             -android-sdk-dir "${ANDROID_SDK_ROOT}" -android-ndk-ver "${ANDROID_NDK_VER}"
       - name: Download and Build Crashpad (include depot_tools)
         if: ${{ steps.depot-cache.outputs.cache-hit != 'true' || steps.crashpad-cache.outputs.cache-hit != 'true' }}
@@ -194,7 +194,7 @@ jobs:
           echo "SIGNING_KEY_PASSWORD=$SIGNING_KEY_PASSWORD" >> $GITHUB_ENV
       - name: Build TGZ packages
         run: |
-          ./tools/build --variant gui --arch ${{ matrix.arch }} --system android --cmake-build-type MinSizeRel \
+          ./tools/build --variant gui --arch ${{ matrix.arch }} --system android --cmake-build-type Release \
             -build-benchmark -build-test \
             -android-sdk-dir "${ANDROID_SDK_ROOT}" -android-ndk-ver "${ANDROID_NDK_VER}"
       - name: Clean up keychain and provisioning profile

--- a/.github/workflows/releases-ios.yml
+++ b/.github/workflows/releases-ios.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x64, arm64]
-        build_type: [MinSizeRel]
+        build_type: [Release]
     env:
       BUILD_TYPE: '${{ matrix.build_type }}'
     steps:

--- a/.github/workflows/releases-openwrt-binary.yml
+++ b/.github/workflows/releases-openwrt-binary.yml
@@ -177,9 +177,9 @@ jobs:
       - name: Build TGZ packages
         run: |
           ./tools/build --variant cli --arch ${{ matrix.arch }} --system linux --subsystem openwrt --sysroot ${{ env.SDK_ROOT }} \
-            --cmake-build-type MinSizeRel -build-benchmark -build-test -nc ${{ matrix.extra_flags }}
+            --cmake-build-type Release -build-benchmark -build-test -nc ${{ matrix.extra_flags }}
           ./tools/build --variant server --arch ${{ matrix.arch }} --system linux --subsystem openwrt --sysroot ${{ env.SDK_ROOT }} \
-            --cmake-build-type MinSizeRel -build-benchmark -build-test -nc ${{ matrix.extra_flags }}
+            --cmake-build-type Release -build-benchmark -build-test -nc ${{ matrix.extra_flags }}
       - name: Run tests (x86 and x86_64)
         if: ${{ matrix.arch_name == 'x86' || matrix.arch_name == 'x86_64' }}
         run: |

--- a/.github/workflows/releases-rpm.yml
+++ b/.github/workflows/releases-rpm.yml
@@ -276,9 +276,9 @@ jobs:
           rm -f *.tar.gz
       - name: Build TGZ packages
         run: |
-          ./tools/build --variant cli --arch ${{ matrix.arch }} --system linux --subsystem musl --sysroot "${{ env.SDK_ROOT }}" -build-test --cmake-build-type MinSizeRel -use-static-build -nc
-          ./tools/build --variant server --arch ${{ matrix.arch }} --system linux --subsystem musl --sysroot "${{ env.SDK_ROOT }}" -build-test --cmake-build-type MinSizeRel -use-static-build -nc
-          ./tools/build --variant gui --arch ${{ matrix.arch }} --system linux --subsystem musl --sysroot "${{ env.SDK_ROOT }}" -build-test --cmake-build-type MinSizeRel -nc
+          ./tools/build --variant cli --arch ${{ matrix.arch }} --system linux --subsystem musl --sysroot "${{ env.SDK_ROOT }}" -build-test --cmake-build-type Release -use-static-build -nc
+          ./tools/build --variant server --arch ${{ matrix.arch }} --system linux --subsystem musl --sysroot "${{ env.SDK_ROOT }}" -build-test --cmake-build-type Release -use-static-build -nc
+          ./tools/build --variant gui --arch ${{ matrix.arch }} --system linux --subsystem musl --sysroot "${{ env.SDK_ROOT }}" -build-test --cmake-build-type Release -nc
       - name: Run tests (i386 and amd64)
         if: ${{ matrix.arch == 'i386' ||  matrix.arch == 'amd64' }}
         run: |


### PR DESCRIPTION
according to performance benchmark, some tls ciphers behaves twice faster with O3 in place of Os.

As side effect, binary increases slightly (aka 0.4Mib).

    $ 7z l yass-android-release-arm64-1.15.0-3-d164f433.apk|grep '\.so'
    1981-01-01 01:01:02 .....      1454640       442424  lib/arm64-v8a/libcrashpad_handler.so
    1981-01-01 01:01:02 .....      6381040      2517657  lib/arm64-v8a/libyass.so
    $ 7z l yass-android-release-arm64-1.15.0-3-fe378beb.apk|grep '\.so'
    1981-01-01 01:01:02 .....      1454640       442424  lib/arm64-v8a/libcrashpad_handler.so
    1981-01-01 01:01:02 .....      6786760      2731654  lib/arm64-v8a/libyass.so

No change when compressed as apk format.

    -rw-r--r--@ 1 hky  staff    11M Oct 16 05:20 yass-android-release-arm64-1.15.0-3-d164f433.apk
    -rw-r--r--@ 1 hky  staff    11M Oct 16 05:21 yass-android-release-arm64-1.15.0-3-fe378beb.apk

Related to #935.