### PR TITLE
build: prepare for fedora 40 in place of fedora 39

### DIFF
--- a/.github/workflows/releases-rpm.yml
+++ b/.github/workflows/releases-rpm.yml
@@ -45,7 +45,7 @@ jobs:
         container:
         - 'centos8'
         - 'centos9'
-        - 'fedora39'
+        - 'fedora40'
         - 'alpine320'
         - 'i386-alpine320'
         - 'armhf-alpine320'
@@ -95,16 +95,15 @@ jobs:
           # - container: 'centos9'
           #   gui_variant: qt6
           #   use_cet: true
-          # - container: 'fedora39'
+          # - container: 'fedora40'
           #   gui_variant: gtk3
           #   use_cet: true
-          # - container: 'fedora39'
+          # - container: 'fedora40'
           #   gui_variant: gtk4
           #   use_cet: true
           # https://rpmfind.net/linux/rpm2html/search.php?query=glibc-devel&submit=Search+...&system=&arch=
-          # glibc: 2.38 for fedora39
           # glibc: 2.39 for fedora40
-          # - container: 'fedora39'
+          # - container: 'fedora40'
           #   gui_variant: qt6
           #   use_cet: true
           # for opensuse users, you can use centos7's rpm packages

--- a/docker/fedora40.Dockerfile
+++ b/docker/fedora40.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM fedora:40
 
 # Install requirements : update repo and install all requirements
 RUN yum clean all && \


### PR DESCRIPTION
fedora 39 is eol on Nov 11, 2024. drop the support for now.

Fixes #1136.