### PR TITLE
[compatiblity] musl/openwrt: don't call madvise any more

### DIFF
--- a/.github/workflows/releases-openwrt-binary.yml
+++ b/.github/workflows/releases-openwrt-binary.yml
@@ -182,10 +182,12 @@ jobs:
           rm -f *.tar.gz
       - name: Build Binary
         run: |
-          ./tools/build --variant cli --arch ${{ matrix.arch }} --system linux --subsystem openwrt --sysroot ${{ env.SDK_ROOT }} \
-            -build-benchmark -build-test -nc ${{ matrix.extra_flags }}
-          ./tools/build --variant server --arch ${{ matrix.arch }} --system linux --subsystem openwrt --sysroot ${{ env.SDK_ROOT }} \
-            -build-benchmark -build-test -nc ${{ matrix.extra_flags }}
+          ./tools/build --variant cli --arch ${{ matrix.arch }} \
+            --system linux --subsystem openwrt --sysroot ${{ env.SDK_ROOT }} \
+            -build-benchmark -build-test -use-static-build -nc ${{ matrix.extra_flags }}
+          ./tools/build --variant server --arch ${{ matrix.arch }} \
+            --system linux --subsystem openwrt --sysroot ${{ env.SDK_ROOT }} \
+            -build-benchmark -build-test -use-static-build -nc ${{ matrix.extra_flags }}
       - name: Run tests (x86 and x86_64)
         if: ${{ matrix.arch_name == 'x86' || matrix.arch_name == 'x86_64' }}
         run: |

--- a/tools/build.go
+++ b/tools/build.go
@@ -1075,7 +1075,9 @@ func buildStageGenerateBuildScript() {
 			cmakeArgs = append(cmakeArgs, "-DUSE_TCMALLOC=on")
 		} else if subsystem == "musl" {
 			cmakeArgs = append(cmakeArgs, "-DUSE_TCMALLOC=off")
-			cmakeArgs = append(cmakeArgs, "-DUSE_MIMALLOC=on")
+			// mimalloc calls madvise internally while
+			// some old system doesn't like it.
+			cmakeArgs = append(cmakeArgs, "-DUSE_MIMALLOC=off")
 		} else {
 			cmakeArgs = append(cmakeArgs, "-DUSE_TCMALLOC=off")
 			cmakeArgs = append(cmakeArgs, "-DUSE_MIMALLOC=off")


### PR DESCRIPTION
See https://github.com/klzgrad/naiveproxy/issues/664.

As side effect, this commit makes openwrt static build to support old openwrt distributions. See https://github.com/klzgrad/naiveproxy/issues/679. Now it is compatible with Asuswrt Merlin and other legacy distros now link newer musl libc statically from OpenWrt 23.05.

As side effect, this commit disables musl's mimalloc support as well, performance degrade expected.