### PR TITLE
tls: use builtin ca store universally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,8 +479,6 @@ cmake_dependent_option(
   USE_SYSTEM_CARES "Build with system or vendored c-ares" OFF
   USE_CARES OFF)
 
-option(USE_BUILTIN_CA_BUNDLE_CRT "Build with embedded ca-bundle.crt support" ON)
-
 option(USE_MBEDTLS "Build with mbedtls support" ON)
 cmake_dependent_option(
   USE_SYSTEM_MBEDTLS "Build with system or vendored mbedtls" OFF
@@ -3162,55 +3160,51 @@ if (APPLE)
 endif()
 
 #
-# optional builtin ca-bundle crt support
+# required builtin ca-bundle crt support
 #
-if (USE_BUILTIN_CA_BUNDLE_CRT)
-  set(ASIO_CA_BUNDLE_CRT_SRC)
+set(ASIO_CA_BUNDLE_CRT_SRC)
 
-  if (WIN32 AND NOT OS_AARCH64)
-    enable_language(ASM_NASM)
-    set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.asm")
-  endif()
-
-  if (WIN32 AND OS_AARCH64)
-    enable_language(ASM)
-    # silence some unsed definitions' warnings
-    if (COMPILER_CLANG)
-      set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wno-unused-command-line-argument")
-    endif()
-    set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.win.s")
-  endif()
-
-  if (OHOS OR ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    enable_language(ASM)
-    # silence some unsed definitions' warnings
-    if (COMPILER_CLANG)
-      set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wno-unused-command-line-argument")
-    endif()
-    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.m32.s")
-    else()
-      set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.s")
-    endif()
-  endif()
-
-  if (APPLE)
-    enable_language(ASM)
-    set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.apple.s")
-  endif()
-
-  if (NOT ASIO_CA_BUNDLE_CRT_SRC)
-    message(FATAL_ERROR "builtin ca bundle crt missing implementation")
-  endif()
-
-  add_library(asio_ca_bundle_crt OBJECT ${ASIO_CA_BUNDLE_CRT_SRC})
-  target_include_directories(asio_ca_bundle_crt PRIVATE third_party/ca-certificates)
-
-  list(APPEND YASS_APP_FEATURES "ca-certificates 20240203.3.98")
-  # macro used in yass_test
-  target_compile_definitions(asio PUBLIC HAVE_BUILTIN_CA_BUNDLE_CRT=1)
-  target_sources(asio PRIVATE $<TARGET_OBJECTS:asio_ca_bundle_crt>)
+if (WIN32 AND NOT OS_AARCH64)
+  enable_language(ASM_NASM)
+  set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.asm")
 endif()
+
+if (WIN32 AND OS_AARCH64)
+  enable_language(ASM)
+  # silence some unsed definitions' warnings
+  if (COMPILER_CLANG)
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wno-unused-command-line-argument")
+  endif()
+  set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.win.s")
+endif()
+
+if (OHOS OR ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  enable_language(ASM)
+  # silence some unsed definitions' warnings
+  if (COMPILER_CLANG)
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wno-unused-command-line-argument")
+  endif()
+  if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.m32.s")
+  else()
+    set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.s")
+  endif()
+endif()
+
+if (APPLE)
+  enable_language(ASM)
+  set(ASIO_CA_BUNDLE_CRT_SRC "third_party/ca-certificates/ca-bundle.crt.apple.s")
+endif()
+
+if (NOT ASIO_CA_BUNDLE_CRT_SRC)
+  message(FATAL_ERROR "builtin ca bundle crt missing implementation")
+endif()
+
+add_library(asio_ca_bundle_crt OBJECT ${ASIO_CA_BUNDLE_CRT_SRC})
+target_include_directories(asio_ca_bundle_crt PRIVATE third_party/ca-certificates)
+
+list(APPEND YASS_APP_FEATURES "ca-certificates 20240203.3.98")
+target_sources(asio PRIVATE $<TARGET_OBJECTS:asio_ca_bundle_crt>)
 
 #
 # required supplementary ca-bundle crt support

--- a/debian/rules
+++ b/debian/rules
@@ -75,7 +75,7 @@ override_dh_auto_configure: CMAKE_OPTIONS += -DUSE_CET=on
 endif
 
 override_dh_auto_configure:
-	dh_auto_configure ${DEB_BUILD_SYSTEM_OPTIONS} -- -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=on -DBUILD_TESTS=on $(CMAKE_OPTIONS) -DCLI=on -DSERVER=on -DUSE_BUILTIN_CA_BUNDLE_CRT=off -DUSE_TCMALLOC=on
+	dh_auto_configure ${DEB_BUILD_SYSTEM_OPTIONS} -- -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=on -DBUILD_TESTS=on $(CMAKE_OPTIONS) -DCLI=on -DSERVER=on -DUSE_TCMALLOC=on
 
 override_dh_auto_build:
 	dh_auto_build ${DEB_BUILD_SYSTEM_OPTIONS} -- -j $(NCPUS)

--- a/doc/yass_cli.md
+++ b/doc/yass_cli.md
@@ -82,8 +82,8 @@ See <https://github.com/Chilledheart/yass/wiki/Usage>.
 * `--padding_support`:
   Enable padding support.
 
-* `--use_ca_bundle_crt`:
-  Use builtin ca-bundle.crt instead of system CA store.
+* `--ca_native`:
+  Load CA certs from the OS.
 
 * `--cacert` _file_:
   Tells where to use the specified certificate _file_ to verify the peer.

--- a/doc/yass_server.md
+++ b/doc/yass_server.md
@@ -81,8 +81,8 @@ See <https://github.com/Chilledheart/yass/wiki/Usage>.
 * `--padding_support`:
   Enable padding support.
 
-* `--use_ca_bundle_crt`:
-  Use builtin ca-bundle.crt instead of system CA store.
+* `--ca_native`:
+  Load CA certs from the OS.
 
 * `--cacert` _file_:
   Tells where to use the specified certificate _file_ to verify the peer.

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -464,7 +464,7 @@ void SetClientUsageMessage(std::string_view exec_path) {
   --method <method> Specify encrypt of method to use
   --limit_rate Limits the rate of response transmission to a client. Uint can be (none), k, m.
   --padding_support Enable padding support
-  --use_ca_bundle_crt Use builtin ca-bundle.crt instead of system CA store
+  --ca_native Load CA certs from the OS
   --cacert <file> Tells where to use the specified certificate file to verify the peer
   --capath <dir> Tells where to use the specified certificate dir to verify the peer
   --certificate_chain_file <file> Use custom certificate chain file to verify server's certificate
@@ -487,7 +487,7 @@ void SetServerUsageMessage(std::string_view exec_path) {
   --method <method> Specify encrypt of method to use
   --limit_rate Limits the rate of response transmission to a client. Uint can be (none), k, m.
   --padding_support Enable padding support
-  --use_ca_bundle_crt Use builtin ca-bundle.crt instead of system CA store
+  --ca_native Load CA certs from the OS
   --cacert <file> Tells where to use the specified certificate file to verify the peer
   --capath <dir> Tells where to use the specified certificate dir to verify the peer
   --certificate_chain_file <file> Use custom certificate chain file to verify server's certificate

--- a/src/net/asio_ssl.cpp
+++ b/src/net/asio_ssl.cpp
@@ -34,20 +34,7 @@
 #include "third_party/boringssl/src/pki/trust_store.h"
 #endif
 
-#ifdef HAVE_BUILTIN_CA_BUNDLE_CRT
-
-// Use internal ca-bundle.crt if necessary
-// we take care of the ca-bundle if windows version is below windows 8.1
-ABSL_FLAG(bool,
-          use_ca_bundle_crt,
-#if defined(_WIN32) && _WIN32_WINNT < 0x0603
-          !IsWindowsVersionBNOrGreater(6, 3, 0),
-#else
-          false,
-#endif
-          "Use internal ca-bundle.crt instead of system CA store.");
-
-#endif  // HAVE_BUILTIN_CA_BUNDLE_CRT
+ABSL_FLAG(bool, ca_native, false, "Load CA certs from the OS.");
 
 std::ostream& operator<<(std::ostream& o, asio::error_code ec) {
 #ifdef _WIN32
@@ -419,32 +406,7 @@ static int load_ca_to_ssl_ctx_path(SSL_CTX* ssl_ctx, const std::string& dir_path
   return count;
 }
 
-static int load_ca_to_ssl_ctx_cacert(SSL_CTX* ssl_ctx) {
-  int count = 0;
-  std::string ca_bundle = absl::GetFlag(FLAGS_cacert);
-  if (!ca_bundle.empty()) {
-    int result = load_ca_to_ssl_ctx_bundle(ssl_ctx, ca_bundle);
-    if (result > 0) {
-      LOG(INFO) << "Loaded ca bundle from: " << ca_bundle << " with " << result << " certificates";
-      count += result;
-    } else {
-      print_openssl_error();
-      LOG(WARNING) << "Loading ca bundle failure from: " << ca_bundle;
-    }
-    return result;
-  }
-  std::string ca_path = absl::GetFlag(FLAGS_capath);
-  if (!ca_path.empty()) {
-    int result = load_ca_to_ssl_ctx_path(ssl_ctx, ca_path);
-    if (result > 0) {
-      LOG(INFO) << "Loaded ca from directory: " << ca_path << " with " << result << " certificates";
-      count += result;
-    }
-  }
-  return count;
-}
-
-static int load_ca_to_ssl_ctx_yass_ca_bundle(SSL_CTX* ssl_ctx) {
+static std::optional<int> load_ca_to_ssl_ctx_yass_ca_bundle(SSL_CTX* ssl_ctx) {
 #ifdef _WIN32
 #define CA_BUNDLE L"yass-ca-bundle.crt"
   // The windows version will automatically look for a CA certs file named 'ca-bundle.crt',
@@ -496,7 +458,7 @@ static int load_ca_to_ssl_ctx_yass_ca_bundle(SSL_CTX* ssl_ctx) {
 
   for (const auto& wca_bundle : ca_bundles) {
     auto ca_bundle = SysWideToUTF8(wca_bundle);
-    VLOG(1) << "Trying to load ca bundle from: " << ca_bundle;
+    VLOG(1) << "Attempt to load ca bundle from: " << ca_bundle;
     int result = load_ca_to_ssl_ctx_bundle(ssl_ctx, ca_bundle);
     if (result > 0) {
       LOG(INFO) << "Loaded ca bundle from: " << ca_bundle << " with " << result << " certificates";
@@ -506,7 +468,39 @@ static int load_ca_to_ssl_ctx_yass_ca_bundle(SSL_CTX* ssl_ctx) {
 #undef CA_BUNDLE
 #endif
 
-  return 0;
+  return std::nullopt;
+}
+
+static std::optional<int> load_ca_to_ssl_ctx_cacert(SSL_CTX* ssl_ctx) {
+  if (absl::GetFlag(FLAGS_ca_native)) {
+    int result = load_ca_to_ssl_ctx_system(ssl_ctx);
+    if (!result) {
+      LOG(WARNING) << "Loading ca bundle failure from system";
+    }
+    return result;
+  }
+  std::string ca_bundle = absl::GetFlag(FLAGS_cacert);
+  if (!ca_bundle.empty()) {
+    int result = load_ca_to_ssl_ctx_bundle(ssl_ctx, ca_bundle);
+    if (result) {
+      LOG(INFO) << "Loaded ca bundle from: " << ca_bundle << " with " << result << " certificates";
+    } else {
+      print_openssl_error();
+      LOG(WARNING) << "Loading ca bundle failure from: " << ca_bundle;
+    }
+    return result;
+  }
+  std::string ca_path = absl::GetFlag(FLAGS_capath);
+  if (!ca_path.empty()) {
+    int result = load_ca_to_ssl_ctx_path(ssl_ctx, ca_path);
+    if (result) {
+      LOG(INFO) << "Loaded ca from directory: " << ca_path << " with " << result << " certificates";
+    } else {
+      LOG(WARNING) << "Loading ca directory failure from: " << ca_path;
+    }
+    return result;
+  }
+  return load_ca_to_ssl_ctx_yass_ca_bundle(ssl_ctx);
 }
 
 #ifdef _WIN32
@@ -595,7 +589,7 @@ int load_ca_to_ssl_store_from_schannel_store(X509_STORE* store, HCERTSTORE cert_
   return count;
 }
 
-void GatherEnterpriseCertsForLocation(HCERTSTORE cert_store, DWORD location, LPCWSTR store_name) {
+void GatherEnterpriseCertsForLocation(LPCSTR provider, HCERTSTORE cert_store, DWORD location, LPCWSTR store_name) {
   if (!(location == CERT_SYSTEM_STORE_LOCAL_MACHINE || location == CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY ||
         location == CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE || location == CERT_SYSTEM_STORE_CURRENT_USER ||
         location == CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY)) {
@@ -606,7 +600,7 @@ void GatherEnterpriseCertsForLocation(HCERTSTORE cert_store, DWORD location, LPC
 
   HCERTSTORE enterprise_root_store = NULL;
 
-  enterprise_root_store = CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, NULL, flags, store_name);
+  enterprise_root_store = CertOpenStore(provider, 0, NULL, flags, store_name);
   if (!enterprise_root_store) {
     return;
   }
@@ -715,18 +709,24 @@ int load_ca_to_ssl_ctx_system(SSL_CTX* ssl_ctx) {
     goto out;
   }
   // Grab the user-added roots.
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"ROOT");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"ROOT");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"ROOT");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_CURRENT_USER, L"ROOT");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY,
+                                   L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE,
+                                   L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_CURRENT_USER, L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY,
+                                   L"ROOT");
 
   // Grab the user-added intermediates (optional).
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"CA");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"CA");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"CA");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_CURRENT_USER, L"CA");
-  GatherEnterpriseCertsForLocation(root_store, CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY,
+                                   L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE,
+                                   L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_CURRENT_USER, L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_W, root_store, CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY,
+                                   L"CA");
 
   count = load_ca_to_ssl_store_from_schannel_store(store, root_store);
 
@@ -737,8 +737,6 @@ int load_ca_to_ssl_ctx_system(SSL_CTX* ssl_ctx) {
 out:
   LOG(INFO) << "Loaded ca from SChannel: " << count << " certificates";
   return count;
-#elif BUILDFLAG(IS_IOS)
-  return 0;
 #elif BUILDFLAG(IS_MAC)
   X509_STORE* store = SSL_CTX_get_cert_store(ssl_ctx);
   int count = 0;
@@ -753,6 +751,108 @@ out:
 out:
   LOG(INFO) << "Loaded ca from SecTrust: " << count << " certificates";
   return count;
+#elif BUILDFLAG(IS_IOS)
+  return 0;
+#else
+  int count = 0;
+  // cert list copied from golang src/crypto/x509/root_unix.go
+  static const char* ca_bundle_paths[] = {
+      "/etc/ssl/certs/ca-certificates.crt",      // Debian/Ubuntu/Gentoo etc.
+      "/etc/pki/tls/certs/ca-bundle.crt",        // Fedora/RHEL
+      "/etc/ssl/ca-bundle.pem",                  // OpenSUSE
+      "/etc/openssl/certs/ca-certificates.crt",  // NetBSD
+      "/etc/ssl/cert.pem",                       // OpenBSD
+      "/usr/local/share/certs/ca-root-nss.crt",  // FreeBSD/DragonFly
+      "/etc/pki/tls/cacert.pem",                 // OpenELEC
+      "/etc/certs/ca-certificates.crt",          // Solaris 11.2+
+  };
+  for (auto ca_bundle : ca_bundle_paths) {
+    int result = load_ca_to_ssl_ctx_bundle(ssl_ctx, ca_bundle);
+    if (result > 0) {
+      LOG(INFO) << "Loaded ca bundle from: " << ca_bundle << " with " << result << " certificates";
+      count += result;
+    }
+  }
+  static const char* ca_paths[] = {
+      "/etc/ssl/certs",                // SLES10/SLES11, https://golang.org/issue/12139
+      "/etc/pki/tls/certs",            // Fedora/RHEL
+      "/system/etc/security/cacerts",  // Android
+  };
+
+  for (auto ca_path : ca_paths) {
+    int result = load_ca_to_ssl_ctx_path(ssl_ctx, ca_path);
+    if (result > 0) {
+      LOG(INFO) << "Loaded ca from directory: " << ca_path << " with " << result << " certificates";
+      count += result;
+    }
+  }
+  return count;
+#endif
+}
+
+int load_ca_to_ssl_ctx_system_extra(SSL_CTX* ssl_ctx) {
+#ifdef _WIN32
+  HCERTSTORE root_store = NULL;
+  int count = 0;
+
+  X509_STORE* store = SSL_CTX_get_cert_store(ssl_ctx);
+  if (!store) {
+    LOG(WARNING) << "Can't get SSL CTX cert store";
+    goto out;
+  }
+  root_store = CertOpenStore(CERT_STORE_PROV_COLLECTION, 0, NULL, 0, nullptr);
+  if (!root_store) {
+    LOG(WARNING) << "Can't get cert store";
+    goto out;
+  }
+  // Grab the user-added roots.
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE,
+                                   L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store,
+                                   CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store,
+                                   CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store, CERT_SYSTEM_STORE_CURRENT_USER,
+                                   L"ROOT");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store,
+                                   CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"ROOT");
+
+  // Grab the user-added intermediates (optional).
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store, CERT_SYSTEM_STORE_LOCAL_MACHINE,
+                                   L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store,
+                                   CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store,
+                                   CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store, CERT_SYSTEM_STORE_CURRENT_USER,
+                                   L"CA");
+  GatherEnterpriseCertsForLocation(CERT_STORE_PROV_SYSTEM_REGISTRY_W, root_store,
+                                   CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"CA");
+
+  count = load_ca_to_ssl_store_from_schannel_store(store, root_store);
+
+  if (!CertCloseStore(root_store, 0)) {
+    PLOG(WARNING) << "CertCloseStore() call failed";
+  }
+
+out:
+  LOG(INFO) << "Loaded user-added ca from SChannel: " << count << " certificates";
+  return count;
+#elif BUILDFLAG(IS_MAC)
+  X509_STORE* store = SSL_CTX_get_cert_store(ssl_ctx);
+  int count = 0;
+  if (!store) {
+    LOG(WARNING) << "Can't get SSL CTX cert store";
+    goto out;
+  }
+  count += load_ca_to_ssl_store_from_sec_trust_domain(store, kSecTrustSettingsDomainAdmin);
+  count += load_ca_to_ssl_store_from_sec_trust_domain(store, kSecTrustSettingsDomainUser);
+
+out:
+  LOG(INFO) << "Loaded user-added ca from SecTrust: " << count << " certificates";
+  return count;
+#elif BUILDFLAG(IS_IOS)
+  return 0;
 #else
   int count = 0;
   // cert list copied from golang src/crypto/x509/root_unix.go
@@ -802,41 +902,19 @@ void load_ca_to_ssl_ctx(SSL_CTX* ssl_ctx) {
   found_isrg_root_x2 = false;
   found_digicert_root_g2 = false;
   found_gts_root_r4 = false;
-  load_ca_to_ssl_ctx_cacert(ssl_ctx);
+  if (load_ca_to_ssl_ctx_cacert(ssl_ctx).has_value()) {
+    goto done;
+  }
 
-#ifdef HAVE_BUILTIN_CA_BUNDLE_CRT
-  if (absl::GetFlag(FLAGS_use_ca_bundle_crt)) {
+  load_ca_to_ssl_ctx_system_extra(ssl_ctx);
+  {
     std::string_view ca_bundle_content(_binary_ca_bundle_crt_start,
                                        _binary_ca_bundle_crt_end - _binary_ca_bundle_crt_start);
     int result = load_ca_to_ssl_ctx_from_mem(ssl_ctx, ca_bundle_content);
-    LOG(WARNING) << "Builtin ca bundle loaded: " << result << " ceritificates";
-    return;
-  }
-#endif  // HAVE_BUILTIN_CA_BUNDLE_CRT
-
-  if (load_ca_to_ssl_ctx_yass_ca_bundle(ssl_ctx) == 0 && load_ca_to_ssl_ctx_system(ssl_ctx) == 0) {
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_OHOS) || BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
-    LOG(WARNING) << "No ceritifcates from system loaded, probably due to outdated system image";
-#elif BUILDFLAG(IS_LINUX)
-    LOG(WARNING) << "No ceritifcates from system loaded, probably due to missing ca-certficates package";
-#elif BUILDFLAG(IS_FREEBSD)
-    LOG(WARNING) << "No ceritifcates from system loaded, probably due to missing ca_root_nss package";
-#elif BUILDFLAG(IS_IOS)
-    // nop
-#else
-    LOG(WARNING) << "No ceritifcates from system keychain loaded, trying builtin ca bundle";
-#endif
-
-#ifdef HAVE_BUILTIN_CA_BUNDLE_CRT
-    std::string_view ca_bundle_content(_binary_ca_bundle_crt_start,
-                                       _binary_ca_bundle_crt_end - _binary_ca_bundle_crt_start);
-    int result = load_ca_to_ssl_ctx_from_mem(ssl_ctx, ca_bundle_content);
-    LOG(WARNING) << "Loaded builtin ca bundle with " << result << " ceritificates";
-#else
-    LOG(WARNING) << "Attempted to load builtin ca bundle not available";
-#endif
+    LOG(INFO) << "Loaded builtin ca bundle with: " << result << " ceritificates";
   }
 
+done:
   // TODO we can add the missing CA if required
   if (!found_isrg_root_x1 || !found_isrg_root_x2 || !found_digicert_root_g2 || !found_gts_root_r4) {
     if (!found_isrg_root_x1) {

--- a/src/net/asio_ssl_internal.hpp
+++ b/src/net/asio_ssl_internal.hpp
@@ -8,17 +8,14 @@
 
 #include <string_view>
 
-#ifdef HAVE_BUILTIN_CA_BUNDLE_CRT
-
 extern "C" const char _binary_ca_bundle_crt_start[];
 extern "C" const char _binary_ca_bundle_crt_end[];
-
-#endif
 
 extern "C" const char _binary_supplementary_ca_bundle_crt_start[];
 extern "C" const char _binary_supplementary_ca_bundle_crt_end[];
 
 int load_ca_to_ssl_ctx_from_mem(SSL_CTX* ssl_ctx, std::string_view cadata);
 int load_ca_to_ssl_ctx_system(SSL_CTX* ssl_ctx);
+int load_ca_to_ssl_ctx_system_extra(SSL_CTX* ssl_ctx);
 
 #endif  // H_NET_ASIO_SSL_INTERNAL

--- a/src/net/asio_ssl_test.cpp
+++ b/src/net/asio_ssl_test.cpp
@@ -7,7 +7,6 @@
 #include "core/utils.hpp"
 #include "net/asio_ssl_internal.hpp"
 
-#ifdef HAVE_BUILTIN_CA_BUNDLE_CRT
 TEST(SSL_TEST, LoadBuiltinCaBundle) {
   bssl::UniquePtr<SSL_CTX> ssl_ctx;
   ssl_ctx.reset(::SSL_CTX_new(::TLS_client_method()));
@@ -17,7 +16,6 @@ TEST(SSL_TEST, LoadBuiltinCaBundle) {
   int result = load_ca_to_ssl_ctx_from_mem(ssl_ctx.get(), ca_bundle_content);
   ASSERT_NE(result, 0);
 }
-#endif
 
 TEST(SSL_TEST, LoadSupplementaryCaBundle) {
   bssl::UniquePtr<SSL_CTX> ssl_ctx;
@@ -33,17 +31,10 @@ TEST(SSL_TEST, LoadSystemCa) {
   bssl::UniquePtr<SSL_CTX> ssl_ctx;
   ssl_ctx.reset(::SSL_CTX_new(::TLS_client_method()));
   int result = load_ca_to_ssl_ctx_system(ssl_ctx.get());
-#ifdef _WIN32
-  if (IsWindowsVersionBNOrGreater(6, 3, 0)) {
-    ASSERT_NE(result, 0);
-  } else {
-    GTEST_SKIP() << "skipped as system version is too low";
-  }
-#elif BUILDFLAG(IS_MAC) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_OHOS) || BUILDFLAG(IS_FREEBSD) || \
-    BUILDFLAG(IS_LINUX) || !defined(HAVE_BUILTIN_CA_BUNDLE_CRT)
-  ASSERT_NE(result, 0);
-#else
+#if BUILDFLAG(IS_IOS)
   // we don't test on iOS
   GTEST_SKIP() << "skipped as system is not supported";
+#else
+  ASSERT_NE(result, 0);
 #endif
 }

--- a/tools/build.go
+++ b/tools/build.go
@@ -1008,8 +1008,6 @@ func buildStageGenerateBuildScript() {
 
 	if systemNameFlag == "android" {
 		cmakeArgs = append(cmakeArgs, fmt.Sprintf("-DUSE_CARES=%s", "ON"))
-		// see #751
-		cmakeArgs = append(cmakeArgs, "-DUSE_BUILTIN_CA_BUNDLE_CRT=off")
 		glog.Infof("Using android ndk version %s", androidNdkVer)
 		NdkDir := filepath.Join(androidSdkDir, "ndk", androidNdkVer)
 		if _, err := os.Stat(NdkDir); errors.Is(err, os.ErrNotExist) {
@@ -1033,7 +1031,6 @@ func buildStageGenerateBuildScript() {
 	}
 
 	if systemNameFlag == "harmony" {
-		cmakeArgs = append(cmakeArgs, "-DUSE_BUILTIN_CA_BUNDLE_CRT=off")
 		if _, err := os.Stat(harmonyNdkDir); errors.Is(err, os.ErrNotExist) {
 			glog.Fatalf("Harmony Ndk Directory at %s demanded", harmonyNdkDir)
 		}
@@ -1052,9 +1049,6 @@ func buildStageGenerateBuildScript() {
 		subsystem := subSystemNameFlag
 		if subSystemNameFlag == "openwrt" {
 			subsystem = "musl"
-		}
-		if subsystem == "musl" {
-			cmakeArgs = append(cmakeArgs, "-DUSE_BUILTIN_CA_BUNDLE_CRT=off")
 		}
 		cmakeArgs = append(cmakeArgs, fmt.Sprintf("-DUSE_CARES=%s", "ON"))
 		gnuType, gnuArch := getGNUTargetTypeAndArch(archFlag, subsystem)
@@ -1086,8 +1080,6 @@ func buildStageGenerateBuildScript() {
 	}
 
 	if systemNameFlag == "freebsd" && sysrootFlag != "" {
-		// depends on ca_root_nss package
-		cmakeArgs = append(cmakeArgs, "-DUSE_BUILTIN_CA_BUNDLE_CRT=off")
 		cmakeArgs = append(cmakeArgs, fmt.Sprintf("-DUSE_CARES=%s", "ON"))
 
 		var llvmTarget string

--- a/yass.spec.in
+++ b/yass.spec.in
@@ -222,7 +222,7 @@ cd build
    -DUSE_CARES=on -DUSE_SYSTEM_CARES="%enable_system_cares_opt" \
    -DUSE_LIBCXX="%enable_libcxx_opt" \
    -DUSE_CET="%enable_cet_opt" \
-   -DENABLE_LTO=on -DENABLE_LLD="%enable_lld_opt" -DUSE_BUILTIN_CA_BUNDLE_CRT=off ..
+   -DENABLE_LTO=on -DENABLE_LLD="%enable_lld_opt" ..
 ninja
 cd ..
 


### PR DESCRIPTION
Add "--ca_native" flag to adopt old behaviour.

Fixes #1151.